### PR TITLE
Add support for reading Faas pyramids

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Maximum tile dimensions are can be configured with the `--tile_width` and `--til
 resolution is no greater than 256x256.
 
 By default, two additional readers (MiraxReader and PyramidTiffReader) are added to the beginning of Bio-Formats' list of reader classes.
-These and any other readers can be removed from the list with the `--exclude_readers` option:
+Either or both of these readers can be excluded with the `--extra-readers` option:
 
-    # exclude the reader for Faas pyramids
-    bin/bioformats2raw /path/to/file.tiff /path/to/n5-pyramid --exclude_readers PyramidTiffReader
-    # exclude MiraxReader and JPEGReader, so .mrxs throws UnknownFormatException
-    bin/bioformats2raw /path/to/file.mrxs /path/to/n5-pyramid --exclude_readers MiraxReader,JPEGReader
+    # only include the reader for .mrxs, exclude the reader for Faas pyramids
+    bin/bioformats2raw /path/to/file.tiff /path/to/n5-pyramid --extra-readers com.glencoesoftware.bioformats2raw.MiraxReader
+    # don't add any additional readers, just use the ones provided by Bio-Formats
+    bin/bioformats2raw /path/to/file.mrxs /path/to/n5-pyramid --extra-readers

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ Run the conversion:
 Maximum tile dimensions are can be configured with the `--tile_width` and `--tile_height` options.  Defaults can be viewed with
 `bin/bioformats2raw --help`.  `--resolutions` is optional; if omitted, the number of resolutions is set so that the smallest
 resolution is no greater than 256x256.
+
+By default, two additional readers (MiraxReader and PyramidTiffReader) are added to the beginning of Bio-Formats' list of reader classes.
+These and any other readers can be removed from the list with the `--exclude_readers` option:
+
+    # exclude the reader for Faas pyramids
+    bin/bioformats2raw /path/to/file.tiff /path/to/n5-pyramid --exclude_readers PyramidTiffReader
+    # exclude MiraxReader and JPEGReader, so .mrxs throws UnknownFormatException
+    bin/bioformats2raw /path/to/file.mrxs /path/to/n5-pyramid --exclude_readers MiraxReader,JPEGReader

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -210,6 +210,7 @@ public class Converter implements Callable<Void> {
 
   @Option(
           names = "--extra-readers",
+          arity = "0..1",
           split = ",",
           description = "Separate set of readers to include; " +
                   "default: ${DEFAULT-VALUE})"

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -278,6 +278,7 @@ public class Converter implements Callable<Void> {
     ClassList<IFormatReader> readerClasses =
         ImageReader.getDefaultReaderClasses();
     readerClasses.addClass(0, MiraxReader.class);
+    readerClasses.addClass(1, PyramidTiffReader.class);
     ImageReader imageReader = new ImageReader(readerClasses);
     Class<?> readerClass;
     try {

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -87,6 +87,12 @@ public class Converter implements Callable<Void> {
   /** Scaling factor in X and Y between any two consecutive resolutions. */
   private static final int PYRAMID_SCALE = 2;
 
+
+  /** Extra readers supplied by bioformats2raw. */
+  private static final Class[] EXTRA_READERS = new Class[] {
+    PyramidTiffReader.class, MiraxReader.class
+  };
+
   static class N5Compression {
     enum CompressionTypes { blosc, bzip2, gzip, lz4, raw, xz };
 
@@ -207,6 +213,14 @@ public class Converter implements Callable<Void> {
   )
   private Integer compressionParameter = null;
 
+  @Option(
+          names = "--exclude_readers",
+          split = ",",
+          description = "Comma-separated list of readers to exclude " +
+                        "(e.g. PyramidTiffReader)"
+  )
+  private List<String> excludedReaders;
+
   /** Scaling implementation that will be used during downsampling. */
   private IImageScaler scaler = new SimpleImageScaler();
 
@@ -277,8 +291,30 @@ public class Converter implements Callable<Void> {
     // First find which reader class we need
     ClassList<IFormatReader> readerClasses =
         ImageReader.getDefaultReaderClasses();
-    readerClasses.addClass(0, MiraxReader.class);
-    readerClasses.addClass(1, PyramidTiffReader.class);
+
+    if (excludedReaders != null) {
+      for (String reader : excludedReaders) {
+        try {
+          Class c = Class.forName("loci.formats.in." + reader);
+          if (c != null) {
+            readerClasses.removeClass(c);
+          }
+        }
+        catch (ClassNotFoundException e) {
+        }
+      }
+      for (Class reader : EXTRA_READERS) {
+        if (!excludedReaders.contains(reader.getSimpleName())) {
+          readerClasses.addClass(0, reader);
+        }
+      }
+    }
+    else {
+      for (Class reader : EXTRA_READERS) {
+        readerClasses.addClass(0, reader);
+      }
+    }
+
     ImageReader imageReader = new ImageReader(readerClasses);
     Class<?> readerClass;
     try {

--- a/src/main/java/com/glencoesoftware/bioformats2raw/PyramidTiffReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/PyramidTiffReader.java
@@ -1,0 +1,305 @@
+/**
+ * Copyright (c) 2020 Glencoe Software, Inc. All rights reserved.
+ *
+ * This software is distributed under the terms described by the LICENSE.txt
+ * file you can find at the root of the distribution bundle.  If the file is
+ * missing please request a copy by contacting info@glencoesoftware.com
+ */
+
+package com.glencoesoftware.bioformats2raw;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import loci.common.RandomAccessInputStream;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.MissingLibraryException;
+import loci.formats.in.BaseTiffReader;
+import loci.formats.meta.IMetadata;
+import loci.formats.meta.MetadataConverter;
+import loci.formats.meta.MetadataStore;
+import loci.formats.services.OMEXMLService;
+import loci.formats.services.OMEXMLServiceImpl;
+import loci.formats.tiff.IFD;
+import loci.formats.tiff.PhotoInterp;
+import loci.formats.tiff.TiffCompression;
+import loci.formats.tiff.TiffParser;
+
+import ome.xml.meta.OMEXMLMetadataRoot;
+import ome.xml.model.Image;
+import ome.xml.model.Pixels;
+import ome.xml.model.TiffData;
+
+/**
+ * PyramidTiffReader is the file format reader for pyramid TIFFs.
+ */
+public class PyramidTiffReader extends BaseTiffReader {
+
+  // -- Constants --
+
+  /** Logger for this class. */
+  private static final Logger LOGGER =
+    LoggerFactory.getLogger(PyramidTiffReader.class);
+
+  // -- Fields --
+
+  private IMetadata omexml = null;;
+
+  // -- Constructor --
+
+  /** Constructs a new pyramid TIFF reader. */
+  public PyramidTiffReader() {
+    super("Pyramid TIFF", new String[] {"tif", "tiff"});
+    domains = new String[] {FormatTools.EM_DOMAIN};
+    suffixSufficient = false;
+    suffixNecessary = false;
+    equalStrips = true;
+    noSubresolutions = true;
+    canSeparateSeries = false;
+  }
+
+  // -- IFormatReader API methods --
+
+  /* @see loci.formats.IFormatReader#isThisType(RandomAccessInputStream) */
+  @Override
+  public boolean isThisType(RandomAccessInputStream stream) throws IOException {
+    TiffParser parser = new TiffParser(stream);
+    parser.setAssumeEqualStrips(equalStrips);
+    IFD ifd = parser.getFirstIFD();
+    if (ifd == null) {
+      return false;
+    }
+    String software = ifd.getIFDTextValue(IFD.SOFTWARE);
+    if (software != null && software.indexOf("Faas") >= 0) {
+      return true;
+    }
+
+    // compare width and height of first and last IFD
+    // all IFDs could be checked, but that may affect performance
+    try {
+      long[] offsets = parser.getIFDOffsets();
+      if (offsets.length == 1) {
+        return false;
+      }
+      IFD lastIFD = parser.getIFD(offsets[offsets.length - 1]);
+
+      if (lastIFD.getImageWidth() >= ifd.getImageWidth() ||
+        lastIFD.getImageLength() >= ifd.getImageLength())
+      {
+        return false;
+      }
+
+      int powerOfTwo = 0;
+      long width = ifd.getImageWidth();
+      while (width > lastIFD.getImageWidth()) {
+        width /= 2;
+        powerOfTwo++;
+      }
+      // don't accept the file if the number of IFDs is not
+      // a multiple of the detected resolution count
+      if (offsets.length % (powerOfTwo + 1) != 0) {
+        return false;
+      }
+
+      long height = ifd.getImageLength() / (int) Math.pow(2, powerOfTwo);
+      return height == lastIFD.getImageLength();
+    }
+    catch (FormatException e) {
+      LOGGER.trace("Could not finish type checking", e);
+    }
+    return false;
+  }
+
+  /**
+   * @see loci.formats.IFormatReader#close(boolean)
+   */
+  @Override
+  public void close(boolean fileOnly) throws IOException {
+    super.close(fileOnly);
+    if (!fileOnly) {
+      omexml = null;
+    }
+  }
+
+  /**
+   * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
+   */
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+    int index = getCoreIndex() * getImageCount() + no;
+    IFD ifd = ifds.get(index);
+    // strip or tile sizes will vary if any kind of compression was used
+    // so not safe to assume that they have equal length
+    TiffCompression compression = ifd.getCompression();
+    tiffParser.setAssumeEqualStrips(
+      compression == TiffCompression.UNCOMPRESSED ||
+      compression == TiffCompression.DEFAULT_UNCOMPRESSED);
+    tiffParser.getSamples(ifds.get(index), buf, x, y, w, h);
+    return buf;
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
+  @Override
+  public int getOptimalTileWidth() {
+    FormatTools.assertId(currentId, true, 1);
+    try {
+      return (int) ifds.get(getCoreIndex() * getImageCount()).getTileWidth();
+    }
+    catch (FormatException e) {
+      LOGGER.debug("", e);
+    }
+    return super.getOptimalTileWidth();
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  @Override
+  public int getOptimalTileHeight() {
+    FormatTools.assertId(currentId, true, 1);
+    try {
+      return (int) ifds.get(getCoreIndex() * getImageCount()).getTileLength();
+    }
+    catch (FormatException e) {
+      LOGGER.debug("", e);
+    }
+    return super.getOptimalTileHeight();
+  }
+
+  // -- Internal BaseTiffReader API methods --
+
+  /* @see loci.formats.in.BaseTiffReader#initStandardMetadata() */
+  @Override
+  protected void initStandardMetadata() throws FormatException, IOException {
+    // count number of consecutive planes with the same XY dimensions
+
+    ifds.addAll(thumbnailIFDs);
+
+    int nPlanes = 1;
+    long baseWidth = ifds.get(0).getImageWidth();
+    long baseHeight = ifds.get(0).getImageLength();
+    for (int i=1; i<ifds.size(); i++) {
+      long width = ifds.get(i).getImageWidth();
+      long height = ifds.get(i).getImageLength();
+      if (width == baseWidth && height == baseHeight) {
+        nPlanes++;
+      }
+      else {
+        break;
+      }
+    }
+
+    int seriesCount = ifds.size() / nPlanes;
+
+    String comment = ifds.get(0).getComment();
+    if (comment != null && comment.length() > 0) {
+      try {
+        ServiceFactory factory = new ServiceFactory();
+        OMEXMLService service = factory.getInstance(OMEXMLService.class);
+        omexml = service.createOMEXMLMetadata(comment);
+      }
+      catch (DependencyException de) {
+        throw new MissingLibraryException(OMEXMLServiceImpl.NO_OME_XML_MSG, de);
+      }
+      catch (ServiceException e) {
+        LOGGER.debug("Could not parse comment as OME-XML", e);
+      }
+    }
+
+    // repopulate core metadata
+    core.clear();
+    core.add();
+    for (int s=0; s<seriesCount; s++) {
+      CoreMetadata ms = new CoreMetadata();
+      core.add(0, ms);
+
+      if (s == 0) {
+        ms.resolutionCount = seriesCount;
+      }
+
+      IFD ifd = ifds.get(s * nPlanes);
+
+      PhotoInterp p = ifd.getPhotometricInterpretation();
+      int samples = ifd.getSamplesPerPixel();
+      ms.rgb = samples > 1 || p == PhotoInterp.RGB;
+
+      long numTileRows = ifd.getTilesPerColumn() - 1;
+      long numTileCols = ifd.getTilesPerRow() - 1;
+
+      ms.sizeX = (int) ifd.getImageWidth();
+      ms.sizeY = (int) ifd.getImageLength();
+      if (omexml != null) {
+        ms.sizeZ = omexml.getPixelsSizeZ(0).getValue();
+        ms.sizeT = omexml.getPixelsSizeT(0).getValue();
+        ms.sizeC = omexml.getPixelsSizeC(0).getValue();
+        ms.dimensionOrder = omexml.getPixelsDimensionOrder(0).getValue();
+      }
+      else {
+        ms.sizeZ = 1;
+        ms.sizeT = 1;
+        ms.sizeC = ms.rgb ? samples : 1;
+        // assuming all planes are channels
+        ms.sizeC *= nPlanes;
+        ms.dimensionOrder = "XYCZT";
+      }
+      ms.littleEndian = ifd.isLittleEndian();
+      ms.indexed = p == PhotoInterp.RGB_PALETTE &&
+        (get8BitLookupTable() != null || get16BitLookupTable() != null);
+      ms.imageCount = nPlanes;
+      ms.pixelType = ifd.getPixelType();
+      ms.metadataComplete = true;
+      ms.interleaved = false;
+      ms.falseColor = false;
+      ms.thumbnail = s > 0;
+    }
+  }
+
+  /* @see loci.formats.BaseTiffReader#initMetadataStore() */
+  @Override
+  protected void initMetadataStore() throws FormatException {
+    boolean setImageNames = true;
+    if (omexml == null) {
+      super.initMetadataStore();
+    }
+    else {
+      OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) omexml.getRoot();
+      List<Image> images = root.copyImageList();
+      for (int i=0; i<images.size(); i++) {
+        Image img = images.get(i);
+        if (i > 0 && !hasFlattenedResolutions()) {
+          root.removeImage(img);
+          continue;
+        }
+        Pixels pix = img.getPixels();
+        List<TiffData> tiffData = pix.copyTiffDataList();
+        for (TiffData t : tiffData) {
+          pix.removeTiffData(t);
+        }
+        if (img.getName() != null) {
+          setImageNames = false;
+        }
+      }
+      omexml.setRoot(root);
+
+      MetadataConverter.convertMetadata(omexml, makeFilterMetadata());
+    }
+
+    if (setImageNames) {
+      MetadataStore store = makeFilterMetadata();
+
+      for (int i=0; i<getSeriesCount(); i++) {
+        store.setImageName("Series " + (i + 1), i);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This should enable conversion from Faas pyramids (pre-6.0.0 pyramid TIFFs) to 6.0.0+ pyramid OME-TIFFs.  ```PyramidTiffReader``` is copied from https://github.com/glencoesoftware/bioformats-private/blob/4655e5c/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java with minor style fixes required by Checkstyle.

Also adds a ```--exclude_readers``` option to remove any reader from the ```ClassList``` passed to ```ImageReader```.  By default, both ```MiraxReader``` and ```PyramidTiffReader``` are included.

