### PR TITLE
Fix issues with little-endian source data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compile ('ome:formats-gpl:6.2.1')
+    compile ('ome:formats-gpl:6.4.0')
     compile ('info.picocli:picocli:3.9.6')
     compile ('org.janelia.saalfeldlab:n5:2.1.2')
     compile ('org.janelia.saalfeldlab:n5-blosc:1.0.0')

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
+    mavenLocal()
     jcenter()
     mavenCentral()
     maven {
@@ -24,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    compile ('ome:formats-gpl:6.2.1')
+    compile ('ome:formats-gpl:6.4.0-SNAPSHOT')
     compile ('info.picocli:picocli:3.9.6')
     compile ('org.janelia.saalfeldlab:n5:2.1.2')
     compile ('org.janelia.saalfeldlab:n5-blosc:1.0.0')

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
-    mavenLocal()
     jcenter()
     mavenCentral()
     maven {
@@ -25,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compile ('ome:formats-gpl:6.4.0-SNAPSHOT')
+    compile ('ome:formats-gpl:6.2.1')
     compile ('info.picocli:picocli:3.9.6')
     compile ('org.janelia.saalfeldlab:n5:2.1.2')
     compile ('org.janelia.saalfeldlab:n5-blosc:1.0.0')


### PR DESCRIPTION
This should be tested together with https://github.com/ome/bioformats/pull/3519.  819e5ae makes it so that this should pick up the local build that includes https://github.com/ome/bioformats/pull/3519:

```
$ cd bioformats
$ git checkout melissalinkert/tiff-offset-overflow
$ mvn clean install
$ cd ../bioformats2raw
$ gradle clean build
```

/cc @douglasrennick, @chris-allan 