### PR TITLE
WIP: n5-aws-s3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,10 @@ repositories {
 dependencies {
     compile ('ome:formats-gpl:6.4.0')
     compile ('info.picocli:picocli:3.9.6')
-    compile ('org.janelia.saalfeldlab:n5:2.1.2')
-    compile ('org.janelia.saalfeldlab:n5-blosc:1.0.0')
+    compile ('org.janelia.saalfeldlab:n5:2.1.6')
+    compile ('org.janelia.saalfeldlab:n5-blosc:1.0.1')
+    compile ('org.janelia.saalfeldlab:n5-aws-s3:3.0.0')
+    compile ('com.amazonaws:aws-java-sdk-s3:1.11.719')
 }
 
 applicationDistribution.from("$projectDir") {

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -250,14 +250,15 @@ public class Converter implements Callable<Void> {
 
   @Option(
           names = "--pyramid-name",
-          description = "Name of pyramid n5 (default: ${DEFAULT-VALUE})"
+          description = "Name of pyramid n5 (default: ${DEFAULT-VALUE}) " +
+                  "[Can break compatibility with raw2ometiff]"
   )
   private String pyramidName = "pyramid.n5";
 
   @Option(
           names = "--scale-format-string",
           description = "Format string for scale paths "+
-                  "[Use \"s%d\" for neuroglancer] +" +
+                  "[Can break compatibility with raw2ometiff] " +
                   "(default: ${DEFAULT-VALUE})"
   )
   private String scaleFormatString = "%d";

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -333,6 +333,11 @@ public class Converter implements Callable<Void> {
   public void convert()
       throws FormatException, IOException, InterruptedException
   {
+    if (!pyramidName.equals("pyramid.n5") || !scaleFormatString.equals("%d")) {
+      LOGGER.info("Output will be incompatible with raw2ometiff " +
+              "(pyramidName: {}, scaleFormatString: {})",
+              pyramidName, scaleFormatString);
+    }
 
     Cache<TilePointer, byte[]> tileCache = CacheBuilder.newBuilder()
         .maximumSize(maxCachedTiles)


### PR DESCRIPTION
I've been playing around with using object stores for n5 volumes using [n5-aws-s3]( https://github.com/saalfeldlab/n5-aws-s3/). This PR is an initial (functional) proof-of-concept.

I'd like to gauge if it's useful to keep this in bioformats2raw, along with suggestions on how to refactor it. My thought is to use a separate class for I/O and/or a factory for creating the correct n5 and file objects.

I used [MockS3](https://github.com/adobe/S3Mock) for local testing.

[This work is with @mellertd at @TheJacksonLaboratory.]