### PR TITLE
Bump n5 version to work with Java >= 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ repositories {
 dependencies {
     compile ('ome:formats-gpl:6.4.0')
     compile ('info.picocli:picocli:3.9.6')
-    compile ('org.janelia.saalfeldlab:n5:2.1.2')
-    compile ('org.janelia.saalfeldlab:n5-blosc:1.0.0')
+    compile ('org.janelia.saalfeldlab:n5:2.1.6')
+    compile ('org.janelia.saalfeldlab:n5-blosc:1.0.1')
 }
 
 applicationDistribution.from("$projectDir") {


### PR DESCRIPTION
I spent longer than I care to admit debugging an error that was relating to my JAVA_HOME no longer pointing to JDK 1.8.

Newer Java releases work with n5 >= 2.1.4: https://github.com/saalfeldlab/n5/pull/59