### PR TITLE
Flags to rename and pyramid.n5 and scaler paths

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -299,6 +299,12 @@ public class Converter implements Callable<Void> {
   public void convert()
       throws FormatException, IOException, InterruptedException
   {
+    if (!pyramidName.equals("pyramid.n5") || !scaleFormatString.equals("%d")) {
+      LOGGER.info("Output will be incompatible with raw2ometiff " +
+              "(pyramidName: {}, scaleFormatString: {})",
+              pyramidName, scaleFormatString);
+    }
+
     Cache<TilePointer, byte[]> tileCache = CacheBuilder.newBuilder()
         .maximumSize(maxCachedTiles)
         .build();

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -222,14 +222,15 @@ public class Converter implements Callable<Void> {
 
   @Option(
           names = "--pyramid-name",
-          description = "Name of pyramid n5 (default: ${DEFAULT-VALUE})"
+          description = "Name of pyramid n5 (default: ${DEFAULT-VALUE}) " +
+                  "[Can break compatibility with raw2ometiff]"
   )
   private String pyramidName = "pyramid.n5";
 
   @Option(
           names = "--scale-format-string",
           description = "Format string for scale paths "+
-                  "[Use \"s%d\" for neuroglancer] +" +
+                  "[Can break compatibility with raw2ometiff] " +
                   "(default: ${DEFAULT-VALUE})"
   )
   private String scaleFormatString = "%d";


### PR DESCRIPTION
neuroglancer's [n5 implementation ](https://github.com/google/neuroglancer/blob/master/src/neuroglancer/datasource/n5/frontend.ts#L352) uses "s%d"  for each scale.

By using "s%d" instead (as an option) allows this an option.  The default remains "%d".