### PR TITLE
Log exception if series 0 fails to write

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -361,7 +361,7 @@ public class Converter implements Callable<Void> {
         write(0);
       }
       catch (Exception e) {
-        LOGGER.error("Error while writing series 0");
+        LOGGER.error("Error while writing series 0", e);
         return;
       }
       finally {


### PR DESCRIPTION
If the output directory exists but is not writeable
by the current user, the error output was:

```
2020-04-03 14:54:49,428 [main] ERROR c.g.bioformats2raw.Converter - Error while writing series 0
```