### PR TITLE
Multi series and ZCT support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'application'
     id 'eclipse'
-    id 'java'
     id 'checkstyle'
 }
 
@@ -14,7 +13,6 @@ targetCompatibility = 1.8
 
 repositories {
     jcenter()
-    mavenCentral()
     maven {
         url 'https://artifacts.openmicroscopy.org/artifactory/repo/'
     }
@@ -24,30 +22,36 @@ repositories {
 }
 
 dependencies {
-    compile ('ome:formats-gpl:6.4.0')
-    compile ('info.picocli:picocli:3.9.6')
-    compile ('org.janelia.saalfeldlab:n5:2.1.6')
-    compile ('org.janelia.saalfeldlab:n5-blosc:1.0.1')
-    compile ('org.janelia.saalfeldlab:n5-zarr:0.0.2-beta')
+    implementation 'ome:formats-gpl:6.4.0'
+    implementation 'info.picocli:picocli:3.9.6'
+    implementation 'org.janelia.saalfeldlab:n5:2.1.6'
+    implementation 'org.janelia.saalfeldlab:n5-blosc:1.0.1'
+    implementation 'org.janelia.saalfeldlab:n5-zarr:0.0.2-beta'
 
     // https://github.com/junit-team/junit5-samples/blob/master/junit5-migration-gradle/build.gradle
     def junit4Version        = '4.12'
     def junitVintageVersion  = '5.2.0'
     def junitJupiterVersion  = '5.2.0'
     def junitPlatformVersion = '1.2.0'
-    testCompile("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
-    testCompile("junit:junit:${junit4Version}")
-    testRuntime("org.junit.vintage:junit-vintage-engine:${junitVintageVersion}")
-    testRuntime("org.junit.platform:junit-platform-launcher:${junitPlatformVersion}")
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}"
+    testImplementation "junit:junit:${junit4Version}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVintageVersion}"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junitPlatformVersion}"
 
     // https://stackoverflow.com/questions/45462987/junit5-with-intellij-and-gradle
-    testImplementation "org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junitJupiterVersion}"
 }
 
-applicationDistribution.from("$projectDir") {
-    include 'LICENSE.txt'
-    include 'bin/*'
+distributions {
+    main {
+        contents {
+            from("$projectDir") {
+                include 'README.md'
+                include 'LICENSE.txt'
+            }
+        }
+    }
 }
 
 checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@ repositories {
         url 'https://artifacts.openmicroscopy.org/artifactory/repo/'
     }
     maven {
+        url 'https://repo.glencoesoftware.com/repository/n5-zarr-snapshots/'
+    }
+    maven {
         url 'https://saalfeldlab.github.io/maven'
     }
 }
@@ -26,7 +29,7 @@ dependencies {
     implementation 'info.picocli:picocli:3.9.6'
     implementation 'org.janelia.saalfeldlab:n5:2.1.6'
     implementation 'org.janelia.saalfeldlab:n5-blosc:1.0.1'
-    implementation 'org.janelia.saalfeldlab:n5-zarr:0.0.2-beta'
+    implementation 'org.janelia.saalfeldlab:n5-zarr:0.0.3-SNAPSHOT'
 
     // https://github.com/junit-team/junit5-samples/blob/master/junit5-migration-gradle/build.gradle
     def junit4Version        = '4.12'

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -407,7 +407,7 @@ public class Converter implements Callable<Void> {
 
         // write the original OME-XML to a file
         if (!Files.exists(outputPath)) {
-            Files.createDirectories(outputPath);
+          Files.createDirectories(outputPath);
         }
         Path omexmlFile = outputPath.resolve("METADATA.ome.xml");
         Files.write(omexmlFile, xml.getBytes(Constants.ENCODING));

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -406,6 +406,9 @@ public class Converter implements Callable<Void> {
         String xml = getService().getOMEXML(meta);
 
         // write the original OME-XML to a file
+        if (!Files.exists(outputPath)) {
+            Files.createDirectories(outputPath);
+        }
         Path omexmlFile = outputPath.resolve("METADATA.ome.xml");
         Files.write(omexmlFile, xml.getBytes(Constants.ENCODING));
       }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -92,6 +92,9 @@ public class Converter implements Callable<Void> {
   /** Scaling factor in X and Y between any two consecutive resolutions. */
   private static final int PYRAMID_SCALE = 2;
 
+  /** Version of the bioformats2raw layout. */
+  public static final Integer LAYOUT = 1;
+
   /** Enumeration that backs the --file_type flag. Instances can be used
    * as a factory method to create {@link N5Reader} and {@link N5Writer}
    * instances.
@@ -768,6 +771,7 @@ public class Converter implements Callable<Void> {
 
     final String pyramidPath = outputPath.resolve(pyramidName).toString();
     final N5Writer n5 = fileType.writer(pyramidPath);
+    n5.setAttribute("/", "bioformats2raw.layout", LAYOUT);
 
     for (int resCounter=0; resCounter<resolutions; resCounter++) {
       final int resolution = resCounter;

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -482,7 +482,7 @@ public class Converter implements Callable<Void> {
     height = (int) Math.min(tileHeight * PYRAMID_SCALE, dimensions[1] - yy);
 
     IFormatReader reader = readers.take();
-    int zct[];
+    int[] zct;
     try {
       zct = reader.getZCTCoords(plane);
     }
@@ -560,7 +560,7 @@ public class Converter implements Callable<Void> {
           InterruptedException
   {
     IFormatReader reader = readers.take();
-    int zct[];
+    int[] zct;
     try {
       zct = reader.getZCTCoords(plane);
     }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -373,10 +373,6 @@ public class Converter implements Callable<Void> {
     try {
       imageReader.setId(inputPath.toString());
       readerClass = imageReader.getReader().getClass();
-      if (dimensionOrder == null) {
-        dimensionOrder =
-            DimensionOrder.fromString(imageReader.getDimensionOrder());
-      }
     }
     finally {
       imageReader.close();

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -503,8 +503,8 @@ public class Converter implements Callable<Void> {
     IFormatReader reader = readers.take();
     long[] startGridPosition;
     try {
-        startGridPosition = getGridPosition(
-          reader, xx / activeTileWidth, yy / activeTileHeight, plane);
+      startGridPosition = getGridPosition(
+        reader, xx / activeTileWidth, yy / activeTileHeight, plane);
     }
     finally {
       readers.put(reader);
@@ -573,7 +573,7 @@ public class Converter implements Callable<Void> {
 
   /**
    * Retrieve the dimensions based on either the configured or input file
-   * dimension order at the current resolution
+   * dimension order at the current resolution.
    * @param reader initialized reader for the input file
    * @param scaledWidth size of the X dimension at the current resolution
    * @param scaledHeight size of the Y dimension at the current resolution
@@ -598,7 +598,7 @@ public class Converter implements Callable<Void> {
 
   /**
    * Retrieve the grid position based on either the configured or input file
-   * dimension order at the current resolution
+   * dimension order at the current resolution.
    * @param reader initialized reader for the input file
    * @param x X position at the current resolution
    * @param y Y position at the current resolution

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -28,6 +28,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 import org.junit.rules.TemporaryFolder;
 
 public class ZarrTest {
@@ -169,6 +170,7 @@ public class ZarrTest {
    * Test using a different tile size from the default (1024) the does not
    * divide evenly.
    */
+  @Disabled("n5-zarr padCrop() is broken")
   @Test
   public void testSetSmallerDefaultWithRemainder() throws Exception {
     input = fake();

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -9,6 +9,7 @@ package com.glencoesoftware.bioformats2raw.test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -19,6 +20,7 @@ import java.util.Map;
 
 import com.glencoesoftware.bioformats2raw.Converter;
 import loci.common.LogbackTools;
+import loci.formats.in.FakeReader;
 
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
@@ -170,16 +172,28 @@ public class ZarrTest {
     assertTool();
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
+
+    // Check series 0 dimensions and special pixels
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
     Assert.assertArrayEquals(
         new long[] {512, 512, 1, 1, 1}, da.getDimensions());
     Assert.assertArrayEquals(
         new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+    ByteBuffer tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 0})
+        .toByteBuffer();
+    int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    Assert.assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+
+    // Check series 1 dimensions and special pixels
     da = z.getDatasetAttributes("/1/0");
     Assert.assertArrayEquals(
         new long[] {512, 512, 1, 1, 1}, da.getDimensions());
     Assert.assertArrayEquals(
         new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+    tile = z.readBlock("/1/0", da, new long[] {0, 0, 0, 0, 0})
+            .toByteBuffer();
+    seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    Assert.assertArrayEquals(new int[] {1, 0, 0, 0, 0}, seriesPlaneNumberZCT);
   }
 
   /**
@@ -191,11 +205,24 @@ public class ZarrTest {
     assertTool();
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
+
+    // Check dimensions and block size
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
     Assert.assertArrayEquals(
         new long[] {512, 512, 2, 1, 1}, da.getDimensions());
     Assert.assertArrayEquals(
         new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+
+    // Check Z 0 special pixels
+    ByteBuffer tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 0})
+        .toByteBuffer();
+    int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    Assert.assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    // Check Z 1 special pixels
+    tile = z.readBlock("/0/0", da, new long[] {0, 0, 1, 0, 0})
+            .toByteBuffer();
+    seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    Assert.assertArrayEquals(new int[] {0, 1, 1, 0, 0}, seriesPlaneNumberZCT);
   }
 
   /**
@@ -207,11 +234,24 @@ public class ZarrTest {
     assertTool();
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
+
+    // Check dimensions and block size
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
     Assert.assertArrayEquals(
         new long[] {512, 512, 1, 2, 1}, da.getDimensions());
     Assert.assertArrayEquals(
         new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+
+    // Check C 0 special pixels
+    ByteBuffer tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 0})
+        .toByteBuffer();
+    int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    Assert.assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    // Check C 1 special pixels
+    tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 1, 0})
+            .toByteBuffer();
+    seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    Assert.assertArrayEquals(new int[] {0, 1, 0, 1, 0}, seriesPlaneNumberZCT);
   }
 
   /**
@@ -223,11 +263,24 @@ public class ZarrTest {
     assertTool();
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
+
+    // Check dimensions and block size
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
     Assert.assertArrayEquals(
         new long[] {512, 512, 1, 1, 2}, da.getDimensions());
     Assert.assertArrayEquals(
         new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+
+    // Check T 0 special pixels
+    ByteBuffer tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 0})
+        .toByteBuffer();
+    int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    Assert.assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    // Check T 1 special pixels
+    tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 1})
+            .toByteBuffer();
+    seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    Assert.assertArrayEquals(new int[] {0, 1, 0, 0, 1}, seriesPlaneNumberZCT);
   }
 
 }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -155,8 +155,10 @@ public class ZarrTest {
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(new long[] {512, 512, 1}, da.getDimensions());
-    Assert.assertArrayEquals(new int[] {128, 128, 1}, da.getBlockSize());
+    Assert.assertArrayEquals(
+        new long[] {512, 512, 1, 1, 1}, da.getDimensions());
+    Assert.assertArrayEquals(
+        new int[] {128, 128, 1, 1, 1}, da.getBlockSize());
   }
 
   /**
@@ -169,11 +171,15 @@ public class ZarrTest {
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(new long[] {512, 512, 1}, da.getDimensions());
-    Assert.assertArrayEquals(new int[] {512, 512, 1}, da.getBlockSize());
+    Assert.assertArrayEquals(
+        new long[] {512, 512, 1, 1, 1}, da.getDimensions());
+    Assert.assertArrayEquals(
+        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
     da = z.getDatasetAttributes("/1/0");
-    Assert.assertArrayEquals(new long[] {512, 512, 1}, da.getDimensions());
-    Assert.assertArrayEquals(new int[] {512, 512, 1}, da.getBlockSize());
+    Assert.assertArrayEquals(
+        new long[] {512, 512, 1, 1, 1}, da.getDimensions());
+    Assert.assertArrayEquals(
+        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
   }
 
 }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -158,6 +158,20 @@ public class ZarrTest {
    * Test alternative dimension order.
    */
   @Test
+  public void testXYCZTDimensionOrder() throws Exception {
+    input = fake("sizeC", "2", "dimOrder", "XYCZT");
+    assertTool();
+    N5ZarrReader z =
+      new N5ZarrReader(output.resolve("data.zarr").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    Assert.assertArrayEquals(
+        new long[] {512, 512, 2, 1, 1}, da.getDimensions());
+  }
+
+  /**
+   * Test using a forced dimension order.
+   */
+  @Test
   public void testSetXYCZTDimensionOrder() throws Exception {
     input = fake("sizeC", "2");
     assertTool("--dimension-order", "XYCZT");
@@ -166,8 +180,6 @@ public class ZarrTest {
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
     Assert.assertArrayEquals(
         new long[] {512, 512, 2, 1, 1}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
   }
 
   /**

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -26,9 +26,9 @@ import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
 import org.junit.rules.TemporaryFolder;
 
 public class ZarrTest {
@@ -170,7 +170,7 @@ public class ZarrTest {
    * Test using a different tile size from the default (1024) the does not
    * divide evenly.
    */
-  @Disabled("n5-zarr padCrop() is broken")
+  @Ignore("n5-zarr padCrop() is broken")
   @Test
   public void testSetSmallerDefaultWithRemainder() throws Exception {
     input = fake();

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import com.glencoesoftware.bioformats2raw.Converter;
 import loci.common.LogbackTools;
 import loci.formats.in.FakeReader;
+import ome.xml.model.enums.DimensionOrder;
+import picocli.CommandLine;
 
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
@@ -36,6 +38,8 @@ public class ZarrTest {
   Path input;
 
   Path output;
+
+  Converter converter;
 
   @Rule
   public TemporaryFolder tmp = new TemporaryFolder();
@@ -63,7 +67,8 @@ public class ZarrTest {
     output = tmp.newFolder().toPath().resolve("test");
     args.add(output.toString());
     try {
-      Converter.main(args.toArray(new String[]{}));
+      converter = new Converter();
+      CommandLine.call(converter, args.toArray(new String[]{}));
       Assert.assertTrue(Files.exists(output.resolve("data.zarr")));
       Assert.assertTrue(Files.exists(output.resolve("METADATA.ome.xml")));
     }
@@ -148,6 +153,7 @@ public class ZarrTest {
   public void testDefaultIsTooBig() throws Exception {
     input = fake();
     assertTool();
+    Assert.assertEquals(DimensionOrder.XYZCT, converter.getDimensionOrder());
   }
 
   /**

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -155,6 +155,20 @@ public class ZarrTest {
   }
 
   /**
+   * Test a fake file conversion and ensure the layout is set.
+   */
+  @Test
+  public void testDefaultLayoutIsSet() throws Exception {
+    input = fake();
+    assertTool();
+    N5ZarrReader z =
+        new N5ZarrReader(output.resolve("data.zarr").toString());
+    Integer layout =
+        z.getAttribute("/", "bioformats2raw.layout", Integer.class);
+    Assert.assertEquals(Converter.LAYOUT, layout);
+  }
+
+  /**
    * Test alternative dimension order.
    */
   @Test

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -146,7 +146,7 @@ public class ZarrTest {
   }
 
   /**
-   * Manually set the tile size.
+   * Test using a different tile size from the default (1024).
    */
   @Test
   public void testSetSmallerDefault() throws Exception {

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -159,4 +159,21 @@ public class ZarrTest {
     Assert.assertArrayEquals(new int[] { 128, 128, 1 }, da.getBlockSize());
   }
 
+  /**
+   * Test more than one series.
+   */
+  @Test
+  public void testMultiSeries() throws Exception {
+    input = fake("series", "2");
+    assertTool();
+    N5ZarrReader z =
+      new N5ZarrReader(output.resolve("data.zarr").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    Assert.assertArrayEquals(new long[] { 512, 512, 1 }, da.getDimensions());
+    Assert.assertArrayEquals(new int[] { 512, 512, 1 }, da.getBlockSize());
+    da = z.getDatasetAttributes("/1/0");
+    Assert.assertArrayEquals(new long[] { 512, 512, 1 }, da.getDimensions());
+    Assert.assertArrayEquals(new int[] { 512, 512, 1 }, da.getBlockSize());
+  }
+
 }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -153,8 +153,8 @@ public class ZarrTest {
     input = fake();
     assertTool("-h", "128", "-w", "128");
     N5ZarrReader z =
-      new N5ZarrReader(output.resolve("pyramid.zarr").toString());
-    DatasetAttributes da = z.getDatasetAttributes("/0");
+      new N5ZarrReader(output.resolve("data.zarr").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
     Assert.assertArrayEquals(new long[] { 512, 512, 1 }, da.getDimensions());
     Assert.assertArrayEquals(new int[] { 128, 128, 1 }, da.getBlockSize());
   }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -144,8 +144,8 @@ public class ZarrTest {
    */
   @Test
   public void testSetSmallerDefault() throws Exception {
-    fake = fake("-h", "128", "-w", "128");
-    assertTool();
+    fake = fake();
+    assertTool("-h", "128", "-w", "128");
   }
 
 }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -166,6 +166,23 @@ public class ZarrTest {
   }
 
   /**
+   * Test using a different tile size from the default (1024) the does not
+   * divide evenly.
+   */
+  @Test
+  public void testSetSmallerDefaultWithRemainder() throws Exception {
+    input = fake();
+    assertTool("-h", "384", "-w", "384");
+    N5ZarrReader z =
+      new N5ZarrReader(output.resolve("data.zarr").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    Assert.assertArrayEquals(
+        new long[] {512, 512, 1, 1, 1}, da.getDimensions());
+    Assert.assertArrayEquals(
+        new int[] {384, 384, 1, 1, 1}, da.getBlockSize());
+  }
+
+  /**
    * Test more than one series.
    */
   @Test

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -155,8 +155,8 @@ public class ZarrTest {
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(new long[] { 512, 512, 1 }, da.getDimensions());
-    Assert.assertArrayEquals(new int[] { 128, 128, 1 }, da.getBlockSize());
+    Assert.assertArrayEquals(new long[] {512, 512, 1}, da.getDimensions());
+    Assert.assertArrayEquals(new int[] {128, 128, 1}, da.getBlockSize());
   }
 
   /**
@@ -169,11 +169,11 @@ public class ZarrTest {
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(new long[] { 512, 512, 1 }, da.getDimensions());
-    Assert.assertArrayEquals(new int[] { 512, 512, 1 }, da.getBlockSize());
+    Assert.assertArrayEquals(new long[] {512, 512, 1}, da.getDimensions());
+    Assert.assertArrayEquals(new int[] {512, 512, 1}, da.getBlockSize());
     da = z.getDatasetAttributes("/1/0");
-    Assert.assertArrayEquals(new long[] { 512, 512, 1 }, da.getDimensions());
-    Assert.assertArrayEquals(new int[] { 512, 512, 1 }, da.getBlockSize());
+    Assert.assertArrayEquals(new long[] {512, 512, 1}, da.getDimensions());
+    Assert.assertArrayEquals(new int[] {512, 512, 1}, da.getBlockSize());
   }
 
 }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -59,10 +59,12 @@ public class ZarrTest {
     }
     args.add("--file_type=zarr");
     args.add(input.toString());
-    output = tmp.newFolder().toPath();
+    output = tmp.newFolder().toPath().resolve("test");
     args.add(output.toString());
     try {
       Converter.main(args.toArray(new String[]{}));
+      Assert.assertTrue(Files.exists(output.resolve("data.zarr")));
+      Assert.assertTrue(Files.exists(output.resolve("METADATA.ome.xml")));
     }
     catch (RuntimeException rt) {
       throw rt;

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -77,6 +77,16 @@ public class ZarrTest {
     return fake(options, null);
   }
 
+  /**
+   * Create a Bio-Formats fake INI file to use for testing.
+   * @param options map of the options to assign as part of the fake filename
+   * from the allowed keys
+   * @param series map of the integer series index and options map (same format
+   * as <code>options</code> to add to the fake INI content
+   * @see https://docs.openmicroscopy.org/bio-formats/6.4.0/developers/
+   * generating-test-images.html#key-value-pairs
+   * @return path to the fake INI file that has been created
+   */
   static Path fake(Map<String, String> options,
           Map<Integer, Map<String, String>> series)
   {

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -27,7 +27,6 @@ import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -216,7 +215,6 @@ public class ZarrTest {
    * Test using a different tile size from the default (1024) the does not
    * divide evenly.
    */
-  @Ignore("n5-zarr padCrop() is broken")
   @Test
   public void testSetSmallerDefaultWithRemainder() throws Exception {
     input = fake();

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import com.glencoesoftware.bioformats2raw.Converter;
 import loci.common.LogbackTools;
 import loci.formats.in.FakeReader;
-import ome.xml.model.enums.DimensionOrder;
 import picocli.CommandLine;
 
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
@@ -153,7 +152,22 @@ public class ZarrTest {
   public void testDefaultIsTooBig() throws Exception {
     input = fake();
     assertTool();
-    Assert.assertEquals(DimensionOrder.XYZCT, converter.getDimensionOrder());
+  }
+
+  /**
+   * Test alternative dimension order.
+   */
+  @Test
+  public void testSetXYCZTDimensionOrder() throws Exception {
+    input = fake("sizeC", "2");
+    assertTool("--dimension-order", "XYCZT");
+    N5ZarrReader z =
+      new N5ZarrReader(output.resolve("data.zarr").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    Assert.assertArrayEquals(
+        new long[] {512, 512, 2, 1, 1}, da.getDimensions());
+    Assert.assertArrayEquals(
+        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
   }
 
   /**

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -182,4 +182,52 @@ public class ZarrTest {
         new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
   }
 
+  /**
+   * Test more than one Z-section.
+   */
+  @Test
+  public void testMultiZ() throws Exception {
+    input = fake("sizeZ", "2");
+    assertTool();
+    N5ZarrReader z =
+      new N5ZarrReader(output.resolve("data.zarr").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    Assert.assertArrayEquals(
+        new long[] {512, 512, 2, 1, 1}, da.getDimensions());
+    Assert.assertArrayEquals(
+        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+  }
+
+  /**
+   * Test more than one channel.
+   */
+  @Test
+  public void testMultiC() throws Exception {
+    input = fake("sizeC", "2");
+    assertTool();
+    N5ZarrReader z =
+      new N5ZarrReader(output.resolve("data.zarr").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    Assert.assertArrayEquals(
+        new long[] {512, 512, 1, 2, 1}, da.getDimensions());
+    Assert.assertArrayEquals(
+        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+  }
+
+  /**
+   * Test more than one timepoint.
+   */
+  @Test
+  public void testMultiT() throws Exception {
+    input = fake("sizeT", "2");
+    assertTool();
+    N5ZarrReader z =
+      new N5ZarrReader(output.resolve("data.zarr").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    Assert.assertArrayEquals(
+        new long[] {512, 512, 1, 1, 2}, da.getDimensions());
+    Assert.assertArrayEquals(
+        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+  }
+
 }


### PR DESCRIPTION
Implementation of multi-series and ZCT support in accordance with #25

- [x] Using a generic data.n5 or similar name for the N5 data
- [x] Dispensing with the secondary JPEG compressed LABELIMAGE.jpg, <series_no>.jpg, etc. files and encoding all series from the source file in ascending stringified order
- [x] Expanding the number of dimensions to 5 (X, Y, C, Z, T) following the Bio-Formats declared, and OME-XML recorded, dimension order setting their size to 1 if missing entirely
- [x] Adding version metadata in a defined location to aid downstream consumers
- [x] Adding an option to optionally force the dimension order

* Using `data.n5` lacking other dissenting opinions
* Option to force dimension order is `--dimension-order`
* Layout version is currently set to `1` and is available on the root (`/`) group at the `bioformats2raw.layout` key