### PR TITLE
Add additional scale format string arguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
     implementation 'ome:formats-gpl:6.4.0'
-    implementation 'info.picocli:picocli:3.9.6'
+    implementation 'info.picocli:picocli:4.2.0'
     implementation 'org.janelia.saalfeldlab:n5:2.1.6'
     implementation 'org.janelia.saalfeldlab:n5-blosc:1.0.1'
     implementation 'org.janelia.saalfeldlab:n5-zarr:0.0.3-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     implementation 'ome:formats-gpl:6.4.0'
     implementation 'info.picocli:picocli:4.2.0'
+    implementation 'com.univocity:univocity-parsers:2.8.4'
     implementation 'org.janelia.saalfeldlab:n5:2.1.6'
     implementation 'org.janelia.saalfeldlab:n5-blosc:1.0.1'
     implementation 'org.janelia.saalfeldlab:n5-zarr:0.0.3-SNAPSHOT'

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -151,6 +152,28 @@ public class ZarrTest {
   public void testDefaultIsTooBig() throws Exception {
     input = fake();
     assertTool();
+  }
+
+  /**
+   * Test additional format string args.
+   */
+  @Test
+  public void testAdditionalScaleFormatStringArgs() throws Exception {
+    input = fake("series", "2");
+    Path csv = Files.createTempFile(null, ".csv");
+    Files.write(csv, Arrays.asList((new String[] {
+      "abc,888,def",
+      "ghi,999,jkl"
+    })));
+    csv.toFile().deleteOnExit();
+    assertTool(
+        "--scale-format-string", "%3$s/%4$s/%1$s/%2$s",
+        "--additional-scale-format-string-args", csv.toString()
+    );
+    N5ZarrReader z =
+            new N5ZarrReader(output.resolve("data.zarr").toString());
+    Assert.assertTrue(z.exists("/abc/888/0/0"));
+    Assert.assertTrue(z.exists("/ghi/999/1/0"));
   }
 
   /**


### PR DESCRIPTION
Adds the capability to manipulate the scale format string through an additional argument CSV in line with the requirements detailed in #25. It is now possible to do all sorts of crazy things with the N5/Zarr hierarchy.

The format string follows the Java formatter style:

 * https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html
 * https://mkyong.com/java/java-string-format-examples/

There is probably an extensive amount of documentation that is possible here the implementation feels sound.