### PR TITLE
Fix edge effects during downsampling

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -591,13 +591,18 @@ public class Converter implements Callable<Void> {
           pathName, datasetAttributes, gridPosition
         ).toByteBuffer();
 
-        int length = blockWidth * bytesPerPixel;
+        int destLength = blockWidth * bytesPerPixel;
+        int srcLength = destLength;
+        if (fileType == FileType.zarr) {
+          // n5/n5-zarr does not de-pad on read
+          srcLength = activeTileWidth;
+        }
         for (int y=0; y<blockHeight; y++) {
-          int srcPos = y * length;
+          int srcPos = y * srcLength;
           int destPos = ((yBlock * width * activeTileHeight)
             + (y * width) + (xBlock * activeTileWidth)) * bytesPerPixel;
           subTile.position(srcPos);
-          subTile.get(tile, destPos, length);
+          subTile.get(tile, destPos, destLength);
         }
       }
     }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -595,7 +595,7 @@ public class Converter implements Callable<Void> {
         int srcLength = destLength;
         if (fileType == FileType.zarr) {
           // n5/n5-zarr does not de-pad on read
-          srcLength = activeTileWidth;
+          srcLength = activeTileWidth * bytesPerPixel;
         }
         for (int y=0; y<blockHeight; y++) {
           int srcPos = y * srcLength;

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -884,10 +884,8 @@ public class Converter implements Callable<Void> {
 
       String resolutionString = "/" +  String.format(
               scaleFormatString, getScaleFormatStringArgs(series, resolution));
-
       n5.createDataset(
-          "/" +  String.format(
-              scaleFormatString, getScaleFormatStringArgs(series, resolution)),
+          resolutionString,
           getDimensions(workingReader, scaledWidth, scaledHeight),
           new int[] {activeTileWidth, activeTileHeight, 1, 1, 1},
           dataType, compression


### PR DESCRIPTION
On read, files in Zarr format must be de-padded. Source from IDR:

 * http://idr.openmicroscopy.org/webclient/?show=image-179706
 * http://idr.openmicroscopy.org/webclient/img_detail/179706/

Before:

![test](https://user-images.githubusercontent.com/487082/80585130-b5a4bd80-8a0a-11ea-9438-975b1f2515b9.png)

After:

![test2](https://user-images.githubusercontent.com/487082/80585145-bb020800-8a0a-11ea-9b69-1aea0dad8934.png)

/cc @will-moore