### PR TITLE
Preserve original metadata key/value pairs in OME-XML

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -425,6 +425,7 @@ public class Converter implements Callable<Void> {
         LOGGER.error("Failed to instantiate reader: {}", readerClass, e);
         return;
       }
+      reader.setOriginalMetadataPopulated(true);
       reader.setFlattenedResolutions(false);
       reader.setMetadataFiltered(true);
       reader.setMetadataStore(createMetadata());


### PR DESCRIPTION
See #37

```showinf -nopix -noflat``` on the output of bioformats2raw + raw2ometiff should show the same metadata table as ```showinf -nopix -noflat``` on the original file. 