### PR TITLE
Add Memoizer to reader stack

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -7,6 +7,7 @@
  */
 package com.glencoesoftware.bioformats2raw;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -308,6 +309,12 @@ public class Converter implements Callable<Void> {
   )
   private volatile DimensionOrder dimensionOrder;
 
+  @Option(
+          names = "--memo-directory",
+          description = "Directory used to store .bfmemo cache files"
+  )
+  private volatile File memoDirectory;
+
   /** Scaling implementation that will be used during downsampling. */
   private volatile IImageScaler scaler = new SimpleImageScaler();
 
@@ -423,7 +430,13 @@ public class Converter implements Callable<Void> {
       Memoizer memoizer;
       try {
         reader = (IFormatReader) readerClass.getConstructor().newInstance();
-        memoizer = new Memoizer(reader);
+        if (memoDirectory == null) {
+          memoizer = new Memoizer(reader);
+        }
+        else {
+          memoizer = new Memoizer(
+            reader, Memoizer.DEFAULT_MINIMUM_ELAPSED, memoDirectory);
+        }
       }
       catch (Exception e) {
         LOGGER.error("Failed to instantiate reader: {}", readerClass, e);

--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -125,9 +125,7 @@ public class MiraxReader extends FormatReader {
 
   private transient JPEGXRCodec jpegxrCodec = new JPEGXRCodec();
 
-  private Cache<TilePointer, byte[]> tileCache = CacheBuilder.newBuilder()
-      .maximumSize(0)  // Disabled
-      .build();
+  private transient Cache<TilePointer, byte[]> tileCache;
 
   // -- Constructor --
 
@@ -197,6 +195,12 @@ public class MiraxReader extends FormatReader {
     // set background color to black instead of the stored fill color
     // this is to match the default behavior of Pannoramic Viewer
     Arrays.fill(buf, (byte) 0);
+
+    if (tileCache == null) {
+      tileCache = CacheBuilder.newBuilder()
+        .maximumSize(0)  // Disabled
+        .build();
+    }
 
     int index = getCoreIndex();
 


### PR DESCRIPTION
This should speed up worker creation.  With a02b817 alone, consecutive runs of ```bin/bioformats2raw file.mrxs pyramid``` resulted in exceptions when reading tiles:

```
java.lang.NullPointerException: null
	at com.google.common.cache.LocalCache.hash(LocalCache.java:1697) ~[guava-27.1-jre.jar:na]
	at com.google.common.cache.LocalCache.getIfPresent(LocalCache.java:3957) ~[guava-27.1-jre.jar:na]
	at com.google.common.cache.LocalCache$LocalManualCache.getIfPresent(LocalCache.java:4867) ~[guava-27.1-jre.jar:na]
	at com.glencoesoftware.bioformats2raw.MiraxReader.openBytes(MiraxReader.java:263) ~[bioformats2raw-0.2.3-SNAPSHOT.jar:na]
	at loci.formats.ReaderWrapper.openBytes(ReaderWrapper.java:348) ~[formats-api-6.4.0.jar:6.4.0]
	at loci.formats.ChannelSeparator.openBytes(ChannelSeparator.java:229) ~[formats-bsd-6.4.0.jar:6.4.0]
	at loci.formats.ChannelSeparator.openBytes(ChannelSeparator.java:161) ~[formats-bsd-6.4.0.jar:6.4.0]
	at com.glencoesoftware.bioformats2raw.Converter.getTile(Converter.java:634) ~[bioformats2raw-0.2.3-SNAPSHOT.jar:na]
	at com.glencoesoftware.bioformats2raw.Converter.processTile(Converter.java:731) ~[bioformats2raw-0.2.3-SNAPSHOT.jar:na]
	at com.glencoesoftware.bioformats2raw.Converter.lambda$saveResolutions$2(Converter.java:923) ~[bioformats2raw-0.2.3-SNAPSHOT.jar:na]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_252]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_252]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_252]
```

00b65ed fixes those NPEs by leaving the tile cache out of the memo file.