### PR TITLE
Set the default worker count to at most 4

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -224,7 +224,10 @@ public class Converter implements Callable<Void> {
     names = "--max_workers",
     description = "Maximum number of workers (default: ${DEFAULT-VALUE})"
   )
-  private volatile int maxWorkers = Runtime.getRuntime().availableProcessors();
+  // cap the default worker count at 4, to prevent problems with
+  // large images that are not tiled
+  private volatile int maxWorkers =
+      (int) Math.min(4, Runtime.getRuntime().availableProcessors());
 
   @Option(
     names = "--max_cached_tiles",


### PR DESCRIPTION
If fewer than 4 processors are available, the processor count is used instead.  If more than 4 processors are available, ```--max_workers``` now needs to be explicitly set in order to use all of them.

This should help to prevent memory exhaustion when converting large untiled images.

I don't think it makes sense to make the same change in raw2ometiff.