### PR TITLE
MRXS: add option for calculating slide dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Either or both of these readers can be excluded with the `--extra-readers` optio
     # don't add any additional readers, just use the ones provided by Bio-Formats
     bioformats2raw /path/to/file.mrxs /path/to/n5-pyramid --extra-readers
 
+Reader-specific options can be specified using `--options`:
+
+    bioformats2raw /path/to/file.mrxs /path/to/n5-pyramid --options mirax.use_metadata_dimensions=false
+
+Be aware when experimenting with different values for `--options` that the corresponding memo (cache) file may need to be
+removed in order for new options to take effect.  This file will be e.g. `/path/to/.file.mrxs.bfmemo`.
+
 The output in `/path/to/n5-pyramid` can be passed to `raw2ometiff` to produce
 an OME-TIFF that can be opened in ImageJ, imported into OMERO, etc. See
 https://github.com/glencoesoftware/raw2ometiff for more information.

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -48,6 +48,7 @@ import loci.formats.ImageWriter;
 import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.MissingLibraryException;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.meta.IMetadata;
 import loci.formats.services.OMEXMLService;
 import loci.formats.services.OMEXMLServiceImpl;
@@ -346,6 +347,15 @@ public class Converter implements Callable<Void> {
   )
   private volatile boolean overwrite = false;
 
+  @Option(
+          arity = "0..1",
+          names = "--options",
+          split = ",",
+          description =
+            "Reader-specific options, in format key=value[,key2=value2]"
+  )
+  private volatile List<String> readerOptions = new ArrayList<String>();
+
   /** Scaling implementation that will be used during downsampling. */
   private volatile IImageScaler scaler = new SimpleImageScaler();
 
@@ -498,6 +508,18 @@ public class Converter implements Callable<Void> {
         LOGGER.error("Failed to instantiate reader: {}", readerClass, e);
         return;
       }
+
+      if (readerOptions.size() > 0) {
+        DynamicMetadataOptions options = new DynamicMetadataOptions();
+        for (String option : readerOptions) {
+          String[] pair = option.split("=");
+          if (pair.length == 2) {
+            options.set(pair[0], pair[1]);
+          }
+        }
+        memoizer.setMetadataOptions(options);
+      }
+
       memoizer.setOriginalMetadataPopulated(true);
       memoizer.setFlattenedResolutions(false);
       memoizer.setMetadataFiltered(true);

--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -774,7 +774,9 @@ public class MiraxReader extends FormatReader {
         m.sizeX = (int) (totalWidth - (overlapX[i] * (divX - 1)));
         m.sizeY = (int) (totalHeight - (overlapY[i] * (divY - 1)));
 
-        if (useMetadataDimensions()) {
+        if (useMetadataDimensions() &&
+          metadataWidth > 0 && metadataHeight > 0)
+        {
           m.sizeX = (int) Math.min(metadataWidth + tileWidth[i], m.sizeX);
           m.sizeY = (int) Math.min(metadataHeight + tileHeight[i], m.sizeY);
         }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -616,12 +616,22 @@ public class MiraxReader extends FormatReader {
             IniTable stitching = data.getTable(stitchingTable);
             String prefix =
               "COMPRESSED_STITCHING_ORIG_SLIDE_SCANNED_AREA_IN_PIXELS__";
-            int tableMinX = Integer.parseInt(stitching.get(prefix + "LEFT"));
-            int tableMinY = Integer.parseInt(stitching.get(prefix + "TOP"));
-            int tableMaxX = Integer.parseInt(stitching.get(prefix + "RIGHT"));
-            int tableMaxY = Integer.parseInt(stitching.get(prefix + "BOTTOM"));
-            metadataWidth = (tableMaxX - tableMinX) + 1;
-            metadataHeight = (tableMaxY - tableMinY) + 1;
+
+            String left = stitching.get(prefix + "LEFT");
+            String top = stitching.get(prefix + "TOP");
+            String right = stitching.get(prefix + "RIGHT");
+            String bottom = stitching.get(prefix + "BOTTOM");
+
+            if (left != null && top != null &&
+              right != null && bottom != null)
+            {
+              int tableMinX = Integer.parseInt(left);
+              int tableMinY = Integer.parseInt(top);
+              int tableMaxX = Integer.parseInt(right);
+              int tableMaxY = Integer.parseInt(bottom);
+              metadataWidth = (tableMaxX - tableMinX) + 1;
+              metadataHeight = (tableMaxY - tableMinY) + 1;
+            }
           }
         }
 

--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -229,9 +229,6 @@ public class MiraxReader extends FormatReader {
     int endX = x + w;
     int endY = y + h;
 
-    double xOverlap = inPyramid ? overlapX[index] : 0;
-    double yOverlap = inPyramid ? overlapY[index] : 0;
-
     double scale = divPerSide / div;
     for (int row=0; row<rowCount; row++) {
       for (int col=0; col<colCount; col++) {
@@ -589,6 +586,7 @@ public class MiraxReader extends FormatReader {
             tilePositions = new int[nTiles][2];
             int minX = Integer.MAX_VALUE;
             int minY = Integer.MAX_VALUE;
+
             for (int t=0; t<nTiles; t++) {
               tilePositions[t][0] =
                 DataTools.bytesToInt(positionData, t * 9 + 1, 4, true);
@@ -602,6 +600,10 @@ public class MiraxReader extends FormatReader {
                 minY = tilePositions[t][1];
               }
             }
+
+            minX -= (minX % 256);
+            minY -= (minY % 256);
+
             for (int t=0; t<nTiles; t++) {
               tilePositions[t][0] -= minX;
               tilePositions[t][1] -= minY;
@@ -661,6 +663,8 @@ public class MiraxReader extends FormatReader {
               minY = tilePositions[t][1];
             }
           }
+          minX -= (minX % 256);
+          minY -= (minY % 256);
           for (int t=0; t<nTiles; t++) {
             tilePositions[t][0] -= minX;
             tilePositions[t][1] -= minY;
@@ -768,11 +772,9 @@ public class MiraxReader extends FormatReader {
       if (i == 0) {
         double totalWidth = tileWidth[i] * tileColCount[i];
         double totalHeight = tileHeight[i] * tileRowCount[i];
-        double divX = tileColCount[0] / div;
-        double divY = tileRowCount[0] / div;
 
-        m.sizeX = (int) (totalWidth - (overlapX[i] * (divX - 1)));
-        m.sizeY = (int) (totalHeight - (overlapY[i] * (divY - 1)));
+        m.sizeX = (int) totalWidth;
+        m.sizeY = (int) totalHeight;
 
         if (useMetadataDimensions() &&
           metadataWidth > 0 && metadataHeight > 0)


### PR DESCRIPTION
This addresses part of #55.

```MiraxReader``` by default now uses a bounding box in the ```Slidedat.ini``` file to calculate the XY dimensions of the largest resolution.  As far as I can tell, this is what CaseViewer (3DHistech's software) uses.  In many cases, the bounding box and the total area of all stitched tiles are not obviously different, but for the dataset referenced in #55 the bounding box is significantly smaller.

In case there are some datasets for which the bounding box strategy is not correct, there is now a ```mirax.use_metadata_dimensions``` option which, when set to ```false``` falls back to the previous behavior.  The command line options and documentation have been updated accordingly, so that the ```--options``` option to ```bioformats2raw``` can be used to provide reader-specific options.  Definitely open to other naming ideas there.