### PR TITLE
Add uint32 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     def junitPlatformVersion = '1.2.0'
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-migrationsupport:${junitJupiterVersion}"
     testImplementation "junit:junit:${junit4Version}"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVintageVersion}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junitPlatformVersion}"
@@ -56,6 +57,10 @@ jar {
             "Implementation-Version": version
         )
     }
+}
+
+test {
+    useJUnitPlatform()
 }
 
 distributions {

--- a/build.gradle
+++ b/build.gradle
@@ -30,20 +30,22 @@ dependencies {
     implementation 'info.picocli:picocli:4.2.0'
     implementation 'com.univocity:univocity-parsers:2.8.4'
     implementation 'org.janelia.saalfeldlab:n5:2.2.0'
-    implementation 'org.janelia.saalfeldlab:n5-blosc:1.1.0'
-    implementation 'org.janelia.saalfeldlab:n5-zarr:0.0.4'
+
+    // exclude JUnit 4 to make sure our tests all use JUnit 5
+    implementation('org.janelia.saalfeldlab:n5-blosc:1.1.0') {
+        exclude group: 'junit', module: 'junit'
+    }
+    implementation('org.janelia.saalfeldlab:n5-zarr:0.0.4') {
+        exclude group: 'junit', module: 'junit'
+    }
     implementation 'org.openpnp:opencv:3.4.2-1'
 
     // https://github.com/junit-team/junit5-samples/blob/master/junit5-migration-gradle/build.gradle
-    def junit4Version        = '4.12'
-    def junitVintageVersion  = '5.2.0'
-    def junitJupiterVersion  = '5.2.0'
-    def junitPlatformVersion = '1.2.0'
+    def junitVintageVersion  = '5.7.0'
+    def junitJupiterVersion  = '5.7.0'
+    def junitPlatformVersion = '1.7.0'
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}"
-    testImplementation "org.junit.jupiter:junit-jupiter-migrationsupport:${junitJupiterVersion}"
-    testImplementation "junit:junit:${junit4Version}"
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVintageVersion}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junitPlatformVersion}"
 
     // https://stackoverflow.com/questions/45462987/junit5-with-intellij-and-gradle

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -63,6 +63,7 @@ import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.DoubleArrayDataBlock;
 import org.janelia.saalfeldlab.n5.FloatArrayDataBlock;
 import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.IntArrayDataBlock;
 import org.janelia.saalfeldlab.n5.Lz4Compression;
 import org.janelia.saalfeldlab.n5.N5FSReader;
 import org.janelia.saalfeldlab.n5.N5FSWriter;
@@ -877,6 +878,13 @@ public class Converter implements Callable<Void> {
           dataBlock = new ShortArrayDataBlock(size, gridPosition, asShort);
           break;
         }
+        case FormatTools.INT32:
+        case FormatTools.UINT32: {
+          int[] asInt = new int[tile.length / 4];
+          bb.asIntBuffer().get(asInt);
+          dataBlock = new IntArrayDataBlock(size, gridPosition, asInt);
+          break;
+        }
         case FormatTools.FLOAT: {
           float[] asFloat = new float[tile.length / 4];
           bb.asFloatBuffer().get(asFloat);
@@ -978,6 +986,12 @@ public class Converter implements Callable<Void> {
         break;
       case FormatTools.UINT16:
         dataType = DataType.UINT16;
+        break;
+      case FormatTools.INT32:
+        dataType = DataType.INT32;
+        break;
+      case FormatTools.UINT32:
+        dataType = DataType.UINT32;
         break;
       case FormatTools.FLOAT:
         dataType = DataType.FLOAT32;

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -36,20 +36,20 @@ import picocli.CommandLine.ExecutionException;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.rules.TemporaryFolder;
 import org.opencv.core.Core;
 
-@EnableRuleMigrationSupport
 public class ZarrTest {
 
   Path input;
@@ -58,16 +58,14 @@ public class ZarrTest {
 
   Converter converter;
 
-  @Rule
-  public TemporaryFolder tmp = new TemporaryFolder();
-
   /**
    * Set logging to warn before all methods.
+   *
+   * @param tmp temporary directory for output file
    */
-  @Before
   @BeforeEach
-  public void setup() throws Exception {
-    output = tmp.newFolder().toPath().resolve("test");
+  public void setup(@TempDir Path tmp) throws Exception {
+    output = tmp.resolve("test");
     LogbackTools.setRootLevel("warn");
   }
 
@@ -87,8 +85,8 @@ public class ZarrTest {
     try {
       converter = new Converter();
       CommandLine.call(converter, args.toArray(new String[]{}));
-      Assert.assertTrue(Files.exists(output.resolve("data.zarr")));
-      Assert.assertTrue(Files.exists(output.resolve("METADATA.ome.xml")));
+      assertTrue(Files.exists(output.resolve("data.zarr")));
+      assertTrue(Files.exists(output.resolve("METADATA.ome.xml")));
     }
     catch (RuntimeException rt) {
       throw rt;
@@ -99,7 +97,7 @@ public class ZarrTest {
   }
 
   static Path fake(String...args) {
-    Assert.assertTrue(args.length %2 == 0);
+    assertTrue(args.length %2 == 0);
     Map<String, String> options = new HashMap<String, String>();
     for (int i = 0; i < args.length; i += 2) {
       options.put(args[i], args[i+1]);
@@ -204,8 +202,8 @@ public class ZarrTest {
     );
     N5ZarrReader z =
             new N5ZarrReader(output.resolve("data.zarr").toString());
-    Assert.assertTrue(z.exists("/abc/888/0/0"));
-    Assert.assertTrue(z.exists("/ghi/999/1/0"));
+    assertTrue(z.exists("/abc/888/0/0"));
+    assertTrue(z.exists("/ghi/999/1/0"));
   }
 
   /**
@@ -219,7 +217,7 @@ public class ZarrTest {
         new N5ZarrReader(output.resolve("data.zarr").toString());
     Integer layout =
         z.getAttribute("/", "bioformats2raw.layout", Integer.class);
-    Assert.assertEquals(Converter.LAYOUT, layout);
+    assertEquals(Converter.LAYOUT, layout);
   }
 
   /**
@@ -234,13 +232,13 @@ public class ZarrTest {
     //
     List<Map<String, Object>> multiscales =
             z.getAttribute("/0", "multiscales", List.class);
-    Assert.assertEquals(1, multiscales.size());
+    assertEquals(1, multiscales.size());
     Map<String, Object> multiscale = multiscales.get(0);
-    Assert.assertEquals("0.1", multiscale.get("version"));
+    assertEquals("0.1", multiscale.get("version"));
     List<Map<String, Object>> datasets =
             (List<Map<String, Object>>) multiscale.get("datasets");
-    Assert.assertTrue(datasets.size() > 0);
-    Assert.assertEquals("0", datasets.get(0).get("path"));
+    assertTrue(datasets.size() > 0);
+    assertEquals("0", datasets.get(0).get("path"));
   }
 
   /**
@@ -253,8 +251,7 @@ public class ZarrTest {
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(
-        new long[] {512, 512, 2, 1, 1}, da.getDimensions());
+    assertArrayEquals(new long[] {512, 512, 2, 1, 1}, da.getDimensions());
   }
 
   /**
@@ -267,8 +264,7 @@ public class ZarrTest {
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(
-        new long[] {512, 512, 2, 1, 1}, da.getDimensions());
+    assertArrayEquals(new long[] {512, 512, 2, 1, 1}, da.getDimensions());
   }
 
   /**
@@ -281,10 +277,8 @@ public class ZarrTest {
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(
-        new long[] {512, 512, 1, 1, 1}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {128, 128, 1, 1, 1}, da.getBlockSize());
+    assertArrayEquals(new long[] {512, 512, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[] {128, 128, 1, 1, 1}, da.getBlockSize());
   }
 
   /**
@@ -298,10 +292,8 @@ public class ZarrTest {
     N5ZarrReader z =
       new N5ZarrReader(output.resolve("data.zarr").toString());
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(
-        new long[] {512, 512, 1, 1, 1}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {384, 384, 1, 1, 1}, da.getBlockSize());
+    assertArrayEquals(new long[] {512, 512, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[] {384, 384, 1, 1, 1}, da.getBlockSize());
   }
 
   /**
@@ -316,25 +308,21 @@ public class ZarrTest {
 
     // Check series 0 dimensions and special pixels
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(
-        new long[] {512, 512, 1, 1, 1}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+    assertArrayEquals(new long[] {512, 512, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
     ByteBuffer tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 0})
         .toByteBuffer();
     int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
-    Assert.assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
 
     // Check series 1 dimensions and special pixels
     da = z.getDatasetAttributes("/1/0");
-    Assert.assertArrayEquals(
-        new long[] {512, 512, 1, 1, 1}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+    assertArrayEquals(new long[] {512, 512, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
     tile = z.readBlock("/1/0", da, new long[] {0, 0, 0, 0, 0})
             .toByteBuffer();
     seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
-    Assert.assertArrayEquals(new int[] {1, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    assertArrayEquals(new int[] {1, 0, 0, 0, 0}, seriesPlaneNumberZCT);
   }
 
   /**
@@ -349,21 +337,19 @@ public class ZarrTest {
 
     // Check dimensions and block size
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(
-        new long[] {512, 512, 2, 1, 1}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+    assertArrayEquals(new long[] {512, 512, 2, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
 
     // Check Z 0 special pixels
     ByteBuffer tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 0})
         .toByteBuffer();
     int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
-    Assert.assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
     // Check Z 1 special pixels
     tile = z.readBlock("/0/0", da, new long[] {0, 0, 1, 0, 0})
             .toByteBuffer();
     seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
-    Assert.assertArrayEquals(new int[] {0, 1, 1, 0, 0}, seriesPlaneNumberZCT);
+    assertArrayEquals(new int[] {0, 1, 1, 0, 0}, seriesPlaneNumberZCT);
   }
 
   /**
@@ -378,21 +364,19 @@ public class ZarrTest {
 
     // Check dimensions and block size
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(
-        new long[] {512, 512, 1, 2, 1}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+    assertArrayEquals(new long[] {512, 512, 1, 2, 1}, da.getDimensions());
+    assertArrayEquals(new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
 
     // Check C 0 special pixels
     ByteBuffer tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 0})
         .toByteBuffer();
     int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
-    Assert.assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
     // Check C 1 special pixels
     tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 1, 0})
             .toByteBuffer();
     seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
-    Assert.assertArrayEquals(new int[] {0, 1, 0, 1, 0}, seriesPlaneNumberZCT);
+    assertArrayEquals(new int[] {0, 1, 0, 1, 0}, seriesPlaneNumberZCT);
   }
 
   /**
@@ -407,21 +391,19 @@ public class ZarrTest {
 
     // Check dimensions and block size
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertArrayEquals(
-        new long[] {512, 512, 1, 1, 2}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+    assertArrayEquals(new long[] {512, 512, 1, 1, 2}, da.getDimensions());
+    assertArrayEquals(new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
 
     // Check T 0 special pixels
     ByteBuffer tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 0})
         .toByteBuffer();
     int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
-    Assert.assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
     // Check T 1 special pixels
     tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 1})
             .toByteBuffer();
     seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
-    Assert.assertArrayEquals(new int[] {0, 1, 0, 0, 1}, seriesPlaneNumberZCT);
+    assertArrayEquals(new int[] {0, 1, 0, 0, 1}, seriesPlaneNumberZCT);
   }
 
   /**
@@ -440,15 +422,13 @@ public class ZarrTest {
 
     // Check series dimensions and special pixels
     DatasetAttributes da = z.getDatasetAttributes("/0/0");
-    Assert.assertEquals(n5Type, da.getDataType());
-    Assert.assertArrayEquals(
-        new long[] {512, 512, 1, 1, 1}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
+    assertEquals(n5Type, da.getDataType());
+    assertArrayEquals(new long[] {512, 512, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[] {512, 512, 1, 1, 1}, da.getBlockSize());
     ByteBuffer tile = z.readBlock("/0/0", da, new long[] {0, 0, 0, 0, 0})
         .toByteBuffer();
     int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
-    Assert.assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    assertArrayEquals(new int[] {0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
   }
 
   /**
@@ -476,15 +456,13 @@ public class ZarrTest {
 
     // Check series dimensions
     DatasetAttributes da = z.getDatasetAttributes("/0/1");
-    Assert.assertArrayEquals(
-        new long[] {30, 150, 1, 1, 1}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {25, 75, 1, 1, 1}, da.getBlockSize());
+    assertArrayEquals(new long[] {30, 150, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[] {25, 75, 1, 1, 1}, da.getBlockSize());
     ByteBuffer tile = z.readBlock("/0/1", da, new long[] {1, 0, 0, 0, 0})
         .toByteBuffer();
     // Last row first pixel should be the 2x2 downsampled value;
     // test will break if the downsampling algorithm changes
-    Assert.assertEquals(50, tile.get(75 * 24));
+    assertEquals(50, tile.get(75 * 24));
   }
 
   /**
@@ -500,16 +478,14 @@ public class ZarrTest {
 
     // Check series dimensions
     DatasetAttributes da = z.getDatasetAttributes("/0/1");
-    Assert.assertEquals(DataType.UINT16, da.getDataType());
-    Assert.assertArrayEquals(
-        new long[] {30, 150, 1, 1, 1}, da.getDimensions());
-    Assert.assertArrayEquals(
-        new int[] {25, 75, 1, 1, 1}, da.getBlockSize());
+    assertEquals(DataType.UINT16, da.getDataType());
+    assertArrayEquals(new long[] {30, 150, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[] {25, 75, 1, 1, 1}, da.getBlockSize());
     ShortBuffer tile = z.readBlock("/0/1", da, new long[] {1, 0, 0, 0, 0})
         .toByteBuffer().asShortBuffer();
     // Last row first pixel should be the 2x2 downsampled value;
     // test will break if the downsampling algorithm changes
-    Assert.assertEquals(50, tile.get(75 * 24));
+    assertEquals(50, tile.get(75 * 24));
   }
 
   /**
@@ -532,10 +508,9 @@ public class ZarrTest {
     OMEXMLMetadata retrieve =
       (OMEXMLMetadata) service.createOMEXMLMetadata(xml.toString());
     Hashtable convertedMetadata = service.getOriginalMetadata(retrieve);
-    Assert.assertEquals(originalMetadata.size(), convertedMetadata.size());
+    assertEquals(originalMetadata.size(), convertedMetadata.size());
     for (String key : originalMetadata.keySet()) {
-      Assert.assertEquals(
-        originalMetadata.get(key), convertedMetadata.get(key));
+      assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
     }
   }
 
@@ -543,11 +518,13 @@ public class ZarrTest {
    * Test that execution fails if the output directory already exists and the
    * <code>--overwrite</code> option has not been supplied.
    */
-  @Test(expected = ExecutionException.class)
+  @Test
   public void testFailIfNoOverwrite() throws IOException {
     input = fake();
     Files.createDirectory(output);
-    assertTool();
+    assertThrows(ExecutionException.class, () -> {
+      assertTool();
+    });
   }
 
   /**
@@ -576,28 +553,28 @@ public class ZarrTest {
           new N5ZarrReader(output.resolve("data.zarr").toString());
     List<Map<String, Object>> multiscales =
           z.getAttribute("/0", "multiscales", List.class);
-    Assert.assertEquals(1, multiscales.size());
+    assertEquals(1, multiscales.size());
     Map<String, Object> multiscale = multiscales.get(0);
-    Assert.assertEquals("0.1", multiscale.get("version"));
+    assertEquals("0.1", multiscale.get("version"));
 
     Map<String, String> metadata =
       (Map<String, String>) multiscale.get("metadata");
-    Assert.assertNotNull(metadata);
+    assertNotNull(metadata);
 
     String version = metadata.get("version");
     String method = metadata.get("method");
-    Assert.assertNotNull(version);
-    Assert.assertNotNull(method);
+    assertNotNull(version);
+    assertNotNull(method);
 
     if (type != Downsampling.SIMPLE) {
-      Assert.assertEquals(type.getName(), multiscale.get("type"));
-      Assert.assertEquals(Core.VERSION, version);
-      Assert.assertEquals("org.opencv.imgproc.Imgproc." +
+      assertEquals(type.getName(), multiscale.get("type"));
+      assertEquals(Core.VERSION, version);
+      assertEquals("org.opencv.imgproc.Imgproc." +
         (type == Downsampling.GAUSSIAN ? "pyrDown" : "resize"), method);
     }
     else {
-      Assert.assertEquals("Bio-Formats " + FormatTools.VERSION, version);
-      Assert.assertEquals("loci.common.image.SimpleImageScaler", method);
+      assertEquals("Bio-Formats " + FormatTools.VERSION, version);
+      assertEquals("loci.common.image.SimpleImageScaler", method);
     }
   }
 


### PR DESCRIPTION
Only simple downsampling is support for uint32 data, as OpenCV does not have a corresponding data type.  Tested with open source ```gatan/qa-11392``` sample file.