### PR TITLE
Initial OME Zarr HCS implementation

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -991,7 +991,7 @@ public class Converter implements Callable<Void> {
               Map<String, Object> image = new HashMap<String, Object>();
               int plateAcq = field.getPlateAcquisitionIndex();
               image.put("acquisition", String.valueOf(plateAcq));
-              image.put("path", plateAcq);
+              image.put("path", String.valueOf(field.getFieldIndex()));
               imageList.add(image);
             }
           }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -49,6 +49,7 @@ import loci.formats.MetadataTools;
 import loci.formats.MissingLibraryException;
 import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.meta.IMetadata;
+import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
 import loci.formats.services.OMEXMLServiceImpl;
 import ome.xml.model.enums.DimensionOrder;
@@ -442,6 +443,7 @@ public class Converter implements Callable<Void> {
       try {
         seriesCount = v.getSeriesCount();
         meta = (IMetadata) v.getMetadataStore();
+        ((OMEXMLMetadata) meta).resolveReferences();
 
         if (!noHCS) {
           noHCS = meta.getPlateCount() == 0;
@@ -969,8 +971,7 @@ public class Converter implements Callable<Void> {
 
           List<Map<String, Object>> imageList =
             new ArrayList<Map<String, Object>>();
-          String fullPath = String.format("%s/%d/%s",
-            platePath, index.getPlateAcquisitionIndex(), wellPath);
+          String fullPath = platePath + "/" + wellPath;
           for (String field : n5.list(fullPath)) {
             Map<String, Object> image = new HashMap<String, Object>();
             image.put("path", field);

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -15,7 +15,6 @@ import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -477,7 +476,7 @@ public class Converter implements Callable<Void> {
       }
 
       if (!noHCS) {
-        scaleFormatString = "%d/%d/%d/%d/%d";
+        scaleFormatString = "%d/%d/%d/%d";
       }
 
       for (int i=0; i<seriesCount; i++) {
@@ -546,7 +545,6 @@ public class Converter implements Callable<Void> {
     List<Object> args = new ArrayList<Object>();
     if (!noHCS) {
       HCSIndex index = hcsIndexes.get(series);
-      args.add(index.getPlateAcquisitionIndex());
       args.add(index.getWellRowIndex());
       args.add(index.getWellColumnIndex());
       args.add(index.getFieldIndex());
@@ -964,7 +962,7 @@ public class Converter implements Callable<Void> {
       new ArrayList<Map<String, Object>>();
     for (int pa=0; pa<meta.getPlateAcquisitionCount(plate); pa++) {
       Map<String, Object> acquisition = new HashMap<String, Object>();
-      acquisition.put("path", String.valueOf(pa));
+      acquisition.put("id", String.valueOf(pa));
       acquisitions.add(acquisition);
     }
     plateMap.put("acquisitions", acquisitions);
@@ -984,12 +982,18 @@ public class Converter implements Callable<Void> {
           List<Map<String, Object>> imageList =
             new ArrayList<Map<String, Object>>();
           String fullPath = platePath + "/" + wellPath;
-          String[] fields = n5.list(fullPath);
-          Arrays.sort(fields);
-          for (String field : fields) {
-            Map<String, Object> image = new HashMap<String, Object>();
-            image.put("path", field);
-            imageList.add(image);
+
+          for (HCSIndex field : hcsIndexes) {
+            if (field.getPlateIndex() == index.getPlateIndex() &&
+              field.getWellRowIndex() == index.getWellRowIndex() &&
+              field.getWellColumnIndex() == index.getWellColumnIndex())
+            {
+              Map<String, Object> image = new HashMap<String, Object>();
+              int plateAcq = field.getPlateAcquisitionIndex();
+              image.put("acquisition", String.valueOf(plateAcq));
+              image.put("path", plateAcq);
+              imageList.add(image);
+            }
           }
 
           Map<String, Object> wellMap = new HashMap<String, Object>();

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -936,7 +936,7 @@ public class Converter implements Callable<Void> {
       List<Map<String, Object>> columns = new ArrayList<Map<String, Object>>();
       for (int c=0; c<meta.getPlateColumns(plate).getValue(); c++) {
         Map<String, Object> column = new HashMap<String, Object>();
-        column.put("name", c);
+        column.put("name", String.valueOf(c));
         columns.add(column);
       }
       plateMap.put("columns", columns);
@@ -944,7 +944,7 @@ public class Converter implements Callable<Void> {
       List<Map<String, Object>> rows = new ArrayList<Map<String, Object>>();
       for (int r=0; r<meta.getPlateRows(plate).getValue(); r++) {
         Map<String, Object> row = new HashMap<String, Object>();
-        row.put("name", r);
+        row.put("name", String.valueOf(r));
         rows.add(row);
       }
       plateMap.put("rows", rows);
@@ -953,7 +953,7 @@ public class Converter implements Callable<Void> {
         new ArrayList<Map<String, Object>>();
       for (int pa=0; pa<meta.getPlateAcquisitionCount(plate); pa++) {
         Map<String, Object> acquisition = new HashMap<String, Object>();
-        acquisition.put("path", pa);
+        acquisition.put("path", String.valueOf(pa));
         acquisitions.add(acquisition);
       }
       plateMap.put("acquisitions", acquisitions);
@@ -963,24 +963,26 @@ public class Converter implements Callable<Void> {
       int maxField = Integer.MIN_VALUE;
       for (HCSIndex index : hcsIndexes) {
         if (index.getPlateIndex() == plate) {
-          String wellPath = index.getWellPath();
+          if (index.getFieldIndex() == 0) {
+            String wellPath = index.getWellPath();
 
-          Map<String, Object> well = new HashMap<String, Object>();
-          well.put("path", wellPath);
-          wells.add(well);
+            Map<String, Object> well = new HashMap<String, Object>();
+            well.put("path", wellPath);
+            wells.add(well);
 
-          List<Map<String, Object>> imageList =
-            new ArrayList<Map<String, Object>>();
-          String fullPath = platePath + "/" + wellPath;
-          for (String field : n5.list(fullPath)) {
-            Map<String, Object> image = new HashMap<String, Object>();
-            image.put("path", field);
-            imageList.add(image);
+            List<Map<String, Object>> imageList =
+              new ArrayList<Map<String, Object>>();
+            String fullPath = platePath + "/" + wellPath;
+            for (String field : n5.list(fullPath)) {
+              Map<String, Object> image = new HashMap<String, Object>();
+              image.put("path", field);
+              imageList.add(image);
+            }
+
+            Map<String, Object> wellMap = new HashMap<String, Object>();
+            wellMap.put("images", imageList);
+            n5.setAttribute(fullPath, "well", wellMap);
           }
-
-          Map<String, Object> wellMap = new HashMap<String, Object>();
-          wellMap.put("images", imageList);
-          n5.setAttribute(fullPath, "well", wellMap);
 
           maxField = (int) Math.max(maxField, index.getFieldIndex());
         }
@@ -988,7 +990,7 @@ public class Converter implements Callable<Void> {
       plateMap.put("wells", wells);
 
 
-      plateMap.put("field_count", maxField);
+      plateMap.put("field_count", maxField + 1);
 
       n5.setAttribute(platePath, "plate", plateMap);
     }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
@@ -144,4 +144,14 @@ public class HCSIndex {
       getWellColumnIndex());
   }
 
+  @Override
+  public String toString() {
+    return String.format("plate=%d, plateAcq=%d, row=%d, col=%d, field=%d",
+      getPlateIndex(),
+      getPlateAcquisitionIndex(),
+      getWellRowIndex(),
+      getWellColumnIndex(),
+      getFieldIndex());
+  }
+
 }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2020 Glencoe Software, Inc. All rights reserved.
+ *
+ * This software is distributed under the terms described by the LICENSE.txt
+ * file you can find at the root of the distribution bundle.  If the file is
+ * missing please request a copy by contacting info@glencoesoftware.com
+ */
+package com.glencoesoftware.bioformats2raw;
+
+import loci.formats.meta.IMetadata;
+
+public class HCSIndex {
+
+  private int plate = -1;
+  private int plateAcquisition = -1;
+  private int wellRow = -1;
+  private int wellColumn = -1;
+  private int field = -1;
+
+  /**
+   * Construct an HCSIndex object representing an Image/series,
+   * using the supplied IMetadata to calculate indexes.
+   *
+   * @param meta IMetadata object containing HCS metadata
+   * @param series OME Image/Bio-Formats series index
+   */
+  public HCSIndex(IMetadata meta, int series) {
+    for (int p=0; p<meta.getPlateCount(); p++) {
+      for (int w=0; w<meta.getWellCount(p); w++) {
+        for (int ws=0; ws<meta.getWellSampleCount(p, w); ws++) {
+          if (meta.getWellSampleIndex(p, w, ws).getValue() == series) {
+            plate = p;
+            field = ws;
+            wellRow = meta.getWellRow(p, w).getValue();
+            wellColumn = meta.getWellColumn(p, w).getValue();
+            String id = meta.getWellSampleID(p, w, ws);
+
+            for (int pa=0; pa<meta.getPlateAcquisitionCount(p); pa++) {
+              for (int s=0; s<meta.getWellSampleRefCount(p, pa); s++) {
+                String refID = meta.getPlateAcquisitionWellSampleRef(p, pa, s);
+                if (id.equals(refID)) {
+                  plateAcquisition = pa;
+                  break;
+                }
+              }
+              if (plateAcquisition >= 0) {
+                break;
+              }
+            }
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * @return plate index
+   */
+  public int getPlateIndex() {
+    return plate;
+  }
+
+  /**
+   * Set plate index.
+   *
+   * @param plateIndex plate index
+   */
+  public void setPlateIndex(int plateIndex) {
+    this.plate = plateIndex;
+  }
+
+  /**
+   * @return plate acquisition index
+   */
+  public int getPlateAcquisitionIndex() {
+    return plateAcquisition;
+  }
+
+  /**
+   * Set plate acquisition index.
+   *
+   * @param plateAcquisitionIndex plate acquisition index
+   */
+  public void setPlateAcquisitionIndex(int plateAcquisitionIndex) {
+    this.plateAcquisition = plateAcquisitionIndex;
+  }
+
+  /**
+   * @return well row index
+   */
+  public int getWellRowIndex() {
+    return wellRow;
+  }
+
+  /**
+   * Set well row index.
+   *
+   * @param wellRowIndex well row index
+   */
+  public void setWellRowIndex(int wellRowIndex) {
+    this.wellRow = wellRowIndex;
+  }
+
+  /**
+   * @return well column index
+   */
+  public int getWellColumnIndex() {
+    return wellColumn;
+  }
+
+  /**
+   * Set well column index.
+   *
+   * @param wellColumnIndex well column index
+   */
+  public void setWellColumnIndex(int wellColumnIndex) {
+    this.wellColumn = wellColumnIndex;
+  }
+
+  /**
+   * @return field index
+   */
+  public int getFieldIndex() {
+    return field;
+  }
+
+  /**
+   * Set field (well sample) index.
+   *
+   * @param fieldIndex field index
+   */
+  public void setFieldIndex(int fieldIndex) {
+    this.field = fieldIndex;
+  }
+
+}

--- a/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
@@ -134,4 +134,14 @@ public class HCSIndex {
     this.field = fieldIndex;
   }
 
+  /**
+   * @return well path relative to the plate group
+   */
+  public String getWellPath() {
+    return String.format("%d/%d/%d",
+      getPlateAcquisitionIndex(),
+      getWellRowIndex(),
+      getWellColumnIndex());
+  }
+
 }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
@@ -138,8 +138,7 @@ public class HCSIndex {
    * @return well path relative to the plate group
    */
   public String getWellPath() {
-    return String.format("%d/%d/%d",
-      getPlateAcquisitionIndex(),
+    return String.format("%d/%d",
       getWellRowIndex(),
       getWellColumnIndex());
   }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -614,10 +614,9 @@ public class ZarrTest {
 
     // check valid group layout
     assertEquals(1, z.list("/").length);
-    assertEquals(1, z.list("/0").length);
-    assertEquals(2, z.list("/0/0").length);
+    assertEquals(2, z.list("/0").length);
     for (int row=0; row<2; row++) {
-      String rowPath = "/0/0/" + row;
+      String rowPath = "/0/" + row;
       assertEquals(3, z.list(rowPath).length);
       for (int col=0; col<3; col++) {
         String colPath = rowPath + "/" + col;
@@ -633,7 +632,7 @@ public class ZarrTest {
 
     // check plate/well level metadata
 
-    Map<String, Object> plate = z.getAttribute("/0", "plate", Map.class);
+    Map<String, Object> plate = z.getAttribute("/", "plate", Map.class);
     assertEquals(2, ((Number) plate.get("field_count")).intValue());
 
     List<Map<String, Object>> acquisitions =

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -613,10 +613,9 @@ public class ZarrTest {
           new N5ZarrReader(output.resolve("data.zarr").toString());
 
     // check valid group layout
-    assertEquals(1, z.list("/").length);
-    assertEquals(2, z.list("/0").length);
+    assertEquals(2, z.list("/").length);
     for (int row=0; row<2; row++) {
-      String rowPath = "/0/" + row;
+      String rowPath = "/" + row;
       assertEquals(3, z.list(rowPath).length);
       for (int col=0; col<3; col++) {
         String colPath = rowPath + "/" + col;
@@ -645,7 +644,7 @@ public class ZarrTest {
       (List<Map<String, Object>>) plate.get("wells");
 
     assertEquals(1, acquisitions.size());
-    assertEquals("0", acquisitions.get(0).get("path"));
+    assertEquals("0", acquisitions.get(0).get("id"));
 
     assertEquals(2, rows.size());
     for (int row=0; row<rows.size(); row++) {
@@ -661,7 +660,7 @@ public class ZarrTest {
     for (int row=0; row<rows.size(); row++) {
       for (int col=0; col<columns.size(); col++) {
         int well = row * columns.size() + col;
-        assertEquals("0/" + row + "/" + col, wells.get(well).get("path"));
+        assertEquals(row + "/" + col, wells.get(well).get("path"));
       }
     }
   }


### PR DESCRIPTION
See https://github.com/ome/omero-ms-zarr/pull/75

Automatically uses HCS layout if a plate is present in the reader's ```MetadataStore```, unless the ```--no-hcs``` option is used.
