### PR TITLE
Add --log-level option to set the specific logging level

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -137,10 +137,14 @@ public class Converter implements Callable<Void> {
   private volatile int tileHeight = 1024;
 
   @Option(
-    names = "--debug",
-    description = "Turn on debug logging"
+    names = {"--log-level", "--debug"},
+    arity = "0..1",
+    description = "Change logging level; valid values are " +
+      "OFF, ERROR, WARN, INFO, DEBUG, TRACE and ALL. " +
+      "(default: ${DEFAULT-VALUE})",
+    fallbackValue = "DEBUG"
   )
-  private volatile boolean debug = false;
+  private volatile String logLevel = "INFO";
 
   @Option(
     names = "--version",
@@ -326,12 +330,7 @@ public class Converter implements Callable<Void> {
 
     ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger)
         LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-    if (debug) {
-      root.setLevel(Level.DEBUG);
-    }
-    else {
-      root.setLevel(Level.INFO);
-    }
+    root.setLevel(Level.toLevel(logLevel));
 
     if (Files.exists(outputPath)) {
       if (!overwrite) {


### PR DESCRIPTION
Default is ```INFO```, and ```--debug``` sets to ```DEBUG```.  ```--log-level``` takes an optional
argument which is one of the logback levels:

http://logback.qos.ch/apidocs/ch/qos/logback/classic/Level.html

If the argument is not specified or is an invalid level name, ```DEBUG``` is used.

See #74.

This shouldn't change the behavior of ```--debug```, and means that ```--log-level``` and ```--debug``` can't both be specified.  There are probably other ways to do the same thing, this is just one option.  Whatever we agree on here should happen in raw2ometiff as well.