### PR TITLE
Do not warn about output incompatibility if using standard Zarr layout

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1090,7 +1090,7 @@ public class Converter implements Callable<Void> {
       pyramidName = "data.zarr";
     }
 
-    if (!pyramidName.equals("data.n5") ||
+    if ((!pyramidName.equals("data.n5") && !pyramidName.equals("data.zarr")) ||
               !scaleFormatString.equals("%d/%d"))
     {
       LOGGER.info("Output will be incompatible with raw2ometiff " +


### PR DESCRIPTION
The output of `bioformats2raw --file_type zarr` should now be a valid input for `raw2ometiff`.