### PR TITLE
Nested chunk storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'ome:formats-gpl:6.5.1'
     implementation 'info.picocli:picocli:4.2.0'
     implementation 'com.univocity:univocity-parsers:2.8.4'
-    implementation 'com.bc.zarr:jzarr:0.3.99-SNAPSHOT'
+    implementation 'com.bc.zarr:jzarr:0.3.3-gs-SNAPSHOT'
 
     implementation 'org.openpnp:opencv:3.4.2-1'
     implementation 'me.tongfei:progressbar:0.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
+    mavenLocal()
     jcenter()
     maven {
         url 'https://artifacts.glencoesoftware.com/artifactory/ome.releases'
@@ -37,7 +38,7 @@ dependencies {
     implementation 'ome:formats-gpl:6.5.1'
     implementation 'info.picocli:picocli:4.2.0'
     implementation 'com.univocity:univocity-parsers:2.8.4'
-    implementation 'com.bc.zarr:jzarr:0.3.2'
+    implementation 'com.bc.zarr:jzarr:0.3.99-SNAPSHOT'
 
     implementation 'org.openpnp:opencv:3.4.2-1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
         url 'https://repo.glencoesoftware.com/repository/n5-zarr-snapshots/'
     }
     maven {
+        url 'https://repo.glencoesoftware.com/repository/jzarr-snapshots'
+    }
+    maven {
         url 'https://maven.scijava.org/content/groups/public'
     }
     maven {

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -193,6 +193,13 @@ public class Converter implements Callable<Void> {
   };
 
   @Option(
+          names = "--nested", negatable=true,
+          description = "Whether to use '/' as the chunk path seprator " +
+                  "(false by default)"
+  )
+  private volatile boolean nested = false;
+
+  @Option(
           names = "--pyramid-name",
           description = "Name of pyramid (default: ${DEFAULT-VALUE}) " +
                   "[Can break compatibility with raw2ometiff]"
@@ -910,6 +917,7 @@ public class Converter implements Callable<Void> {
               workingReader, scaledWidth, scaledHeight))
           .chunks(new int[] {1, 1, 1, activeTileHeight, activeTileWidth})
           .dataType(dataType)
+          .nested(nested)
           .compressor(CompressorFactory.create(
               compressionType.toString(), compressionProperties));
       root.createArray(resolutionString, arrayParams);

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -32,6 +32,7 @@ import loci.formats.FormatTools;
 import loci.formats.in.FakeReader;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
+import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 import picocli.CommandLine.ExecutionException;
 
@@ -642,6 +643,18 @@ public class ZarrTest {
       assertEquals("Bio-Formats " + FormatTools.VERSION, version);
       assertEquals("loci.common.image.SimpleImageScaler", method);
     }
+  }
+
+  /**
+   * Test that nested storage works equivalently.
+   *
+   * @param nested whether to use "/" or "." as the chunk separator.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testNestedStorage(boolean nested) throws IOException {
+    input = fake();
+    assertTool(nested ? "--nested" : "--no-nested");
   }
 
 }


### PR DESCRIPTION
Allow using N5-style chunk separators ("/") to prevent an obscene number (10s of millions) of chunks in a single directory. This was found while working on https://github.com/ome/ngff-latency-benchmark/pull/14 since directory metadata methods like file listings became the bottleneck.

This depends on https://github.com/bcdev/jzarr/pull/17 for the underlying logic.

To access these from zarr-python, a release of https://github.com/zarr-developers/zarr-python/pull/699 will be necessary.