### PR TITLE
Retain existing resolutions and add chunking in Z

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -109,7 +109,7 @@
         <!-- Checks for Size Violations.                    -->
         <!-- See https://checkstyle.org/config_sizes.html -->
         <!--<module name="MethodLength"/>-->
-        <module name="ParameterNumber"/>
+        <!--<module name="ParameterNumber"/>-->
 
         <!-- Checks for whitespace                               -->
         <!-- See https://checkstyle.org/config_whitespace.html -->

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -109,7 +109,7 @@
         <!-- Checks for Size Violations.                    -->
         <!-- See https://checkstyle.org/config_sizes.html -->
         <!--<module name="MethodLength"/>-->
-        <!--<module name="ParameterNumber"/>-->
+        <module name="ParameterNumber"/>
 
         <!-- Checks for whitespace                               -->
         <!-- See https://checkstyle.org/config_whitespace.html -->

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -151,7 +151,6 @@ public class Converter implements Callable<Void> {
   @Option(
     names = {"-z", "--chunk_depth"},
     description = "Maximum chunk depth to read (default: ${DEFAULT-VALUE}) "
-        + "[Will break compatibility with raw2ometiff]"
   )
   private volatile int chunkDepth = 1;
 
@@ -330,7 +329,8 @@ public class Converter implements Callable<Void> {
 
   @Option(
       names = "--use-existing-resolutions",
-      description = "Use existing sub resolutions from original input format"
+      description = "Use existing sub resolutions from original input format" +
+          "[Will break compatibility with raw2ometiff]"
 
   )
   private volatile boolean reuseExistingResolutions = false;

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1043,8 +1043,9 @@ public class Converter implements Callable<Void> {
     try {
       // calculate a reasonable pyramid depth if not specified as an argument
       if (pyramidResolutions == null) {
-        if (workingReader.getResolutionCount() > 1 
-            && reuseExistingResolutions) {
+        if (workingReader.getResolutionCount() > 1
+            && reuseExistingResolutions)
+        {
           resolutions = workingReader.getResolutionCount();
         }
         else {
@@ -1100,8 +1101,9 @@ public class Converter implements Callable<Void> {
 
       workingReader = readers.take();
       try {
-        if (workingReader.getResolutionCount() > 1 
-            && reuseExistingResolutions) {
+        if (workingReader.getResolutionCount() > 1
+            && reuseExistingResolutions)
+        {
           workingReader.setResolution(resCounter);
           scaledWidth = workingReader.getSizeX();
           scaledHeight = workingReader.getSizeY();

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -150,7 +150,8 @@ public class Converter implements Callable<Void> {
 
   @Option(
     names = {"-z", "--chunk_depth"},
-    description = "Maximum chunk depth to read (default: ${DEFAULT-VALUE})"
+    description = "Maximum chunk depth to read (default: ${DEFAULT-VALUE}) "
+        + "[Will break compatibility with raw2ometiff]"
   )
   private volatile int chunkDepth = 1;
 
@@ -326,6 +327,13 @@ public class Converter implements Callable<Void> {
 
   )
   private volatile boolean noRootGroup = false;
+  
+  @Option(
+      names = "--use-existing-resolutions",
+      description = "Use existing sub resolutions from original input format"
+
+  )
+  private volatile boolean reuseExistingResolutions = false;
 
   /** Scaling implementation that will be used during downsampling. */
   private volatile IImageScaler scaler = new SimpleImageScaler();
@@ -865,7 +873,7 @@ public class Converter implements Callable<Void> {
   {
     IFormatReader reader = readers.take();
     try {
-      if (reader.getResolutionCount() > 1) {
+      if (reader.getResolutionCount() > 1 && reuseExistingResolutions) {
         reader.setResolution(resolution);
         return reader.openBytes(plane, xx, yy, width, height);
       }
@@ -1081,7 +1089,7 @@ public class Converter implements Callable<Void> {
     try {
       // calculate a reasonable pyramid depth if not specified as an argument
       if (pyramidResolutions == null) {
-        if (workingReader.getResolutionCount() > 1) {
+        if (workingReader.getResolutionCount() > 1 && reuseExistingResolutions) {
           resolutions = workingReader.getResolutionCount();
         }
         else {
@@ -1137,7 +1145,7 @@ public class Converter implements Callable<Void> {
 
       workingReader = readers.take();
       try {
-        if (workingReader.getResolutionCount() > 1) {
+        if (workingReader.getResolutionCount() > 1 && reuseExistingResolutions) {
           workingReader.setResolution(resCounter);
           scaledWidth = workingReader.getSizeX();
           scaledHeight = workingReader.getSizeY();


### PR DESCRIPTION
This work was intended initially for the NGFF benchmarking file generation and is built on top of the open jzarr PR.

Resolutions:
- automatically writes existing resolutions if they are present in the file rather than downsampling
- may make sense to add a flag to trigger the behaviour

3d chunking:
- adds the option to pass a parameter to enable chunking in Z
- tests need to be added
- if the original file is downsampled in Z then the additional resolutions will appear as separate images rather than resolutions. This is due to a Bio-Formats limitation