### PR TITLE
OpenCV library loading cleanup

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1037,12 +1037,12 @@ public class Converter implements Callable<Void> {
                     resolution, plane, xx, yy, width, height);
                 future.complete(null);
               }
-              catch (Exception e) {
-                future.completeExceptionally(e);
+              catch (Throwable t) {
+                future.completeExceptionally(t);
                 LOGGER.error(
                   "Failure processing tile; resolution={} plane={} " +
                   "xx={} yy={} width={} height={}",
-                  resolution, plane, xx, yy, width, height, e);
+                  resolution, plane, xx, yy, width, height, t);
               }
             });
           }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/OpenCVTools.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/OpenCVTools.java
@@ -32,6 +32,7 @@ public class OpenCVTools {
   public static void loadOpenCV() {
     try {
       nu.pattern.OpenCV.loadLocally();
+      return;
     }
     catch (Throwable e) {
       LOGGER.warn("Could not load OpenCV libraries", e);


### PR DESCRIPTION
Couple small fixes to help when debugging OpenCV issues and avoid spurious OpenCV library load issues in logs.