### PR TITLE
Retrieve OME-XML from ChannelSeparator, not base reader

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -440,12 +440,13 @@ public class Converter implements Callable<Void> {
       memoizer.setFlattenedResolutions(false);
       memoizer.setMetadataFiltered(true);
       memoizer.setMetadataStore(createMetadata());
-      memoizer.setId(inputPath.toString());
-      memoizer.setResolution(0);
+      ChannelSeparator separator = new ChannelSeparator(memoizer);
+      separator.setId(inputPath.toString());
+      separator.setResolution(0);
       if (reader instanceof MiraxReader) {
         ((MiraxReader) reader).setTileCache(tileCache);
       }
-      readers.add(new ChannelSeparator(memoizer));
+      readers.add(separator);
     }
 
     // Finally, perform conversion on all series

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -887,7 +887,7 @@ public class ZarrTest {
     input = fake("sizeC", "3", "rgb", "3");
     assertTool();
 
-    Path xml = output.resolve("METADATA.ome.xml");
+    Path xml = output.resolve("data.zarr").resolve("METADATA.ome.xml");
     ServiceFactory sf = new ServiceFactory();
     OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
     OME ome = (OME) xmlService.createOMEXMLRoot(

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -10,6 +10,7 @@ package com.glencoesoftware.bioformats2raw.test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -32,6 +33,8 @@ import loci.formats.FormatTools;
 import loci.formats.in.FakeReader;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
+import ome.xml.model.OME;
+import ome.xml.model.Pixels;
 import picocli.CommandLine;
 import picocli.CommandLine.ExecutionException;
 
@@ -860,6 +863,24 @@ public class ZarrTest {
         assertEquals(0, field2.get("acquisition"));
       }
     }
+  }
+
+  /**
+   * Convert an RGB image.  Ensure that the Channels are correctly split.
+   */
+  @Test
+  public void testRGBChannelSeparator() throws Exception {
+    input = fake("sizeC", "3", "rgb", "3");
+    assertTool();
+
+    Path xml = output.resolve("METADATA.ome.xml");
+    ServiceFactory sf = new ServiceFactory();
+    OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
+    OME ome = (OME) xmlService.createOMEXMLRoot(
+        new String(Files.readAllBytes(xml), StandardCharsets.UTF_8));
+    assertEquals(1, ome.sizeOfImageList());
+    Pixels pixels = ome.getImage(0).getPixels();
+    assertEquals(3, pixels.sizeOfChannelList());
   }
 
 }


### PR DESCRIPTION
This gives ChannelSeparator the chance to copy channel metadata in the case of RGB source data.

Without this change, ```METADATA.ome.xml``` would have a single ```Channel``` with ```SamplesPerPixel``` set to 3.  This doesn't match how the pixel data is actually converted.  raw2ometiff will then change the ```SamplesPerPixel``` to 1 and insert 2 more channels (https://github.com/glencoesoftware/raw2ometiff/blob/master/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java#L442) with no metadata.

With this change, ```METADATA.ome.xml``` should have 3 ```Channel```s with ```SamplesPerPixel``` set to 1 and identical names.  The output of raw2ometiff should preserve this, so that there are no unnamed channels.

Only RGB input data (i.e. ```reader.isRGB()``` returns true) is affected.