### PR TITLE
ngff spec 0.2: default to nested storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This option is not present in 0.3.0 and later, as only Zarr output is supported.
 
 Versions 0.2.6 and prior used the input file's dimension order to determine the output
 dimension order, unless `--dimension-order` was specified.
-Version 0.3.0 uses the `TCZYX` order by default, for compatibility with https://ngff.openmicroscopy.org/0.1/#image-layout.
+Version 0.3.0 uses the `TCZYX` order by default, for compatibility with https://ngff.openmicroscopy.org/0.2/#image-layout.
 The `--dimension-order` option can still be used to set a specific output dimension order, e.g.:
 
     bioformats2raw /path/to/file.mrxs /path/to/zarr-pyramid --dimension-order XYCZT

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -221,7 +221,7 @@ public class Converter implements Callable<Void> {
           description = "Whether to use '/' as the chunk path seprator " +
                   "(false by default)"
   )
-  private volatile boolean nested = false;
+  private volatile boolean nested = true;
 
   @Option(
           names = "--pyramid-name",
@@ -1308,7 +1308,7 @@ public class Converter implements Callable<Void> {
       multiscale.put("type", downsampling.getName());
     }
     multiscale.put("metadata", metadata);
-    multiscale.put("version", "0.1");
+    multiscale.put("version", nested ? "0.2" : "0.1");
     multiscales.add(multiscale);
     List<Map<String, String>> datasets = new ArrayList<Map<String, String>>();
     for (int r = 0; r < resolutions; r++) {

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -235,7 +235,7 @@ public class ZarrTest {
             z.getAttributes().get("multiscales");
     assertEquals(1, multiscales.size());
     Map<String, Object> multiscale = multiscales.get(0);
-    assertEquals("0.1", multiscale.get("version"));
+    assertEquals("0.2", multiscale.get("version"));
     List<Map<String, Object>> datasets =
             (List<Map<String, Object>>) multiscale.get("datasets");
     assertTrue(datasets.size() > 0);
@@ -725,7 +725,7 @@ public class ZarrTest {
           (List<Map<String, Object>>) z.getAttributes().get("multiscales");
     assertEquals(1, multiscales.size());
     Map<String, Object> multiscale = multiscales.get(0);
-    assertEquals("0.1", multiscale.get("version"));
+    assertEquals("0.2", multiscale.get("version"));
 
     Map<String, String> metadata =
       (Map<String, String>) multiscale.get("metadata");


### PR DESCRIPTION
This also updates the version added to the metadata
based on the nested flag. In the future, this logic
will need to be more sophisticated.

see: https://github.com/ome/ngff/pull/40