### PR TITLE
If --no-hcs is passed, remove all HCS metadata from the OME-XML

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -492,6 +492,9 @@ public class Converter implements Callable<Void> {
           for (int i=0; i<toRemove; i++) {
             root.removeImage(root.getImage(0));
           }
+          for (int i=0; i<meta.getPlateCount(); i++) {
+            root.removePlate(root.getPlate(0));
+          }
           meta.setRoot(root);
         }
         else {

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -492,8 +492,10 @@ public class Converter implements Callable<Void> {
           for (int i=0; i<toRemove; i++) {
             root.removeImage(root.getImage(0));
           }
-          for (int i=0; i<meta.getPlateCount(); i++) {
-            root.removePlate(root.getPlate(0));
+          if (noHCS) {
+            for (int i=0; i<meta.getPlateCount(); i++) {
+              root.removePlate(root.getPlate(0));
+            }
           }
           meta.setRoot(root);
         }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -477,6 +477,14 @@ public class Converter implements Callable<Void> {
         if (!noHCS) {
           noHCS = meta.getPlateCount() == 0;
         }
+        else {
+          ((OMEXMLMetadata) meta).resolveReferences();
+          OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) meta.getRoot();
+          for (int i=0; i<meta.getPlateCount(); i++) {
+            root.removePlate(root.getPlate(0));
+          }
+          meta.setRoot(root);
+        }
 
         if (seriesList.size() > 0) {
           ((OMEXMLMetadata) meta).resolveReferences();
@@ -491,11 +499,6 @@ public class Converter implements Callable<Void> {
 
           for (int i=0; i<toRemove; i++) {
             root.removeImage(root.getImage(0));
-          }
-          if (noHCS) {
-            for (int i=0; i<meta.getPlateCount(); i++) {
-              root.removePlate(root.getPlate(0));
-            }
           }
           meta.setRoot(root);
         }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -789,6 +789,10 @@ public class ZarrTest {
     assertArrayEquals(new int[] {1, 1, 1, 512, 512}, series0.getShape());
     assertArrayEquals(new int[] {1, 1, 1, 512, 512}, series0.getChunks());
     assertEquals(12, z.getGroupKeys().size());
+
+    // Check OME metadata
+    OME ome = getOMEMetadata();
+    assertEquals(0, ome.sizeOfPlateList());
   }
 
   /**
@@ -847,6 +851,10 @@ public class ZarrTest {
         checkWell(wellGroup, fieldCount);
       }
     }
+
+    // check OME metadata
+    OME ome = getOMEMetadata();
+    assertEquals(1, ome.sizeOfPlateList());
   }
 
   /**
@@ -1001,11 +1009,7 @@ public class ZarrTest {
     input = fake("sizeC", "3", "rgb", "3");
     assertTool();
 
-    Path xml = output.resolve("OME").resolve("METADATA.ome.xml");
-    ServiceFactory sf = new ServiceFactory();
-    OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
-    OME ome = (OME) xmlService.createOMEXMLRoot(
-        new String(Files.readAllBytes(xml), StandardCharsets.UTF_8));
+    OME ome = getOMEMetadata();
     assertEquals(1, ome.sizeOfImageList());
     Pixels pixels = ome.getImage(0).getPixels();
     assertEquals(3, pixels.sizeOfChannelList());
@@ -1096,4 +1100,11 @@ public class ZarrTest {
     }
   }
 
+  private OME getOMEMetadata() throws Exception {
+    Path xml = output.resolve("OME").resolve("METADATA.ome.xml");
+    ServiceFactory sf = new ServiceFactory();
+    OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
+    return (OME) xmlService.createOMEXMLRoot(
+      new String(Files.readAllBytes(xml), StandardCharsets.UTF_8));
+  }
 }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -776,7 +776,7 @@ public class ZarrTest {
    * The output should not be compliant with OME Zarr HCS.
    */
   @Test
-  public void testNoHCSOption() throws IOException {
+  public void testNoHCSOption() throws Exception {
     input = fake(
       "plates", "1", "plateAcqs", "1",
       "plateRows", "2", "plateCols", "3", "fields", "2");
@@ -800,7 +800,7 @@ public class ZarrTest {
    * The output should be compliant with OME Zarr HCS.
    */
   @Test
-  public void testHCSMetadata() throws IOException {
+  public void testHCSMetadata() throws Exception {
     input = fake(
       "plates", "1", "plateAcqs", "1",
       "plateRows", "2", "plateCols", "3", "fields", "2");


### PR DESCRIPTION
See also a simlar change done in `ImageConverter` in https://github.com/ome/bioformats/pull/3259

In the scenario where the input data is HCS but the `--no-hcs` flag is passed, the `plate/row/col` groups are not created in the Zarr  layout. This change also removes the HCS metadata from the OME-XML file exported under the `OME` group.

In the scenario where both `--no-hcs` and `--series` are passed, this should prevent reference issues e.g. if the file is reconverted into OME-TIFF.

A simple example can be tested using a fake file e.g. 

```
bioformats2raw --no-hcs --series 0 "test&plates=1&plateRows=2&plateCols=2.fake" out
```

The HCS conversion unit tests have been expanded to test the existence of a `Plate` element with or without the `--no-hcs` flag.