### PR TITLE
Fix nested/no-nested values

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -217,9 +217,9 @@ public class Converter implements Callable<Void> {
   };
 
   @Option(
-          names = "--nested", negatable=true,
+          names = "--no-nested", negatable=true,
           description = "Whether to use '/' as the chunk path seprator " +
-                  "(false by default)"
+                  "(true by default)"
   )
   private volatile boolean nested = true;
 


### PR DESCRIPTION
When passing either `--nested` or `--no-nested` (rather than depending
on the default), the logic was reverseed. From https://picocli.info/#_negatable_options

> "When a negatable option is true by default, give it the negative name."