### PR TITLE
Allow to override min_size via command-line argument

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -362,10 +362,12 @@ public class Converter implements Callable<Void> {
   private volatile boolean reuseExistingResolutions = false;
 
   @Option(
-      names = "--min-size",
-      description = "Minimum size of the largest XY dimension in the" +
-          "smallest resolution, when calculating the number of resolutions" +
-          " generate."
+      names = "--target-min-size",
+      description = "Specifies the desired size for the largest XY dimension " +
+          "of the smallest resolution, when calculating the number " +
+          "of resolutions generate. If the target size cannot be matched " +
+          "exactly, the largest XY dimension of the smallest resolution " +
+          "should be smaller than the target size."
   )
   private volatile int minSize = MIN_SIZE;
 

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -361,6 +361,15 @@ public class Converter implements Callable<Void> {
   )
   private volatile boolean reuseExistingResolutions = false;
 
+  @Option(
+      names = "--min-size",
+      description = "Minimum size of the largest XY dimension in the" +
+          "smallest resolution, when calculating the number of resolutions" +
+          " generate."
+  )
+  private volatile int minSize = MIN_SIZE;
+
+
   /** Scaling implementation that will be used during downsampling. */
   private volatile IImageScaler scaler = new SimpleImageScaler();
 
@@ -1113,7 +1122,7 @@ public class Converter implements Callable<Void> {
         else {
           int width = workingReader.getSizeX();
           int height = workingReader.getSizeY();
-          while (width > MIN_SIZE || height > MIN_SIZE) {
+          while (width > minSize || height > minSize) {
             resolutions++;
             width /= PYRAMID_SCALE;
             height /= PYRAMID_SCALE;

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1206,6 +1206,29 @@ public class ZarrTest {
     }
   }
 
+  /**
+   * Convert an image with the --min-size option.
+   */
+  @Test
+  public void testMinSizeOption() throws Exception {
+    input = fake();
+    assertTool("--min-size", "32");
+
+    ZarrGroup z = ZarrGroup.open(output.resolve("0").toString());
+    List<Map<String, Object>> multiscales = (List<Map<String, Object>>)
+            z.getAttributes().get("multiscales");
+
+    Map<String, Object> multiscale = multiscales.get(0);
+    List<Map<String, Object>> datasets =
+              (List<Map<String, Object>>) multiscale.get("datasets");
+
+    String last_path = (String) datasets.get(datasets.size()  - 1).get("path");
+    ZarrArray last_array = z.openArray(last_path);
+
+    assert last_array.getShape()[0] < 32;
+    assert last_array.getShape()[1] < 32;
+  }
+
   private void checkPlateGroupLayout(Path root, int rowCount, int colCount,
     int fieldCount, int x, int y)
     throws IOException

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1207,10 +1207,10 @@ public class ZarrTest {
   }
 
   /**
-   * Convert an image with the --min-size option.
+   * Convert an image to produce smaller resolution of XY dimensions 32x32
    */
   @Test
-  public void testMinSizeOption() throws Exception {
+  public void testMinSizeExact() throws Exception {
     input = fake();
     assertTool("--min-size", "32");
 
@@ -1227,6 +1227,29 @@ public class ZarrTest {
     assertArrayEquals(new int[] {1, 1, 1, 512, 512}, array.getShape());
     array = z.openArray("4");
     assertArrayEquals(new int[] {1, 1, 1, 32, 32}, array.getShape());
+  }
+
+  /**
+   * Convert an image to produce smaller resolution of XY dimensions 16x16
+   */
+  @Test
+  public void testMinSizeThreshold() throws Exception {
+    input = fake();
+    assertTool("--min-size", "30");
+
+    ZarrGroup z = ZarrGroup.open(output.resolve("0").toString());
+    List<Map<String, Object>> multiscales = (List<Map<String, Object>>)
+            z.getAttributes().get("multiscales");
+
+    Map<String, Object> multiscale = multiscales.get(0);
+    List<Map<String, Object>> datasets =
+              (List<Map<String, Object>>) multiscale.get("datasets");
+    assertEquals(datasets.size(), 6);
+
+    ZarrArray array = z.openArray("0");
+    assertArrayEquals(new int[] {1, 1, 1, 512, 512}, array.getShape());
+    array = z.openArray("5");
+    assertArrayEquals(new int[] {1, 1, 1, 16, 16}, array.getShape());
   }
 
   private void checkPlateGroupLayout(Path root, int rowCount, int colCount,

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1221,12 +1221,12 @@ public class ZarrTest {
     Map<String, Object> multiscale = multiscales.get(0);
     List<Map<String, Object>> datasets =
               (List<Map<String, Object>>) multiscale.get("datasets");
+    assertEquals(datasets.size(), 5);
 
-    String lastPath = (String) datasets.get(datasets.size()  - 1).get("path");
-    ZarrArray lastArray = z.openArray(lastPath);
-
-    assert lastArray.getShape()[0] < 32;
-    assert lastArray.getShape()[1] < 32;
+    ZarrArray array = z.openArray("0");
+    assertArrayEquals(new int[] {1, 1, 1, 512, 512}, array.getShape());
+    array = z.openArray("4");
+    assertArrayEquals(new int[] {1, 1, 1, 32, 32}, array.getShape());
   }
 
   private void checkPlateGroupLayout(Path root, int rowCount, int colCount,

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1212,7 +1212,7 @@ public class ZarrTest {
   @Test
   public void testMinSizeExact() throws Exception {
     input = fake();
-    assertTool("--min-size", "32");
+    assertTool("--target-min-size", "32");
 
     ZarrGroup z = ZarrGroup.open(output.resolve("0").toString());
     List<Map<String, Object>> multiscales = (List<Map<String, Object>>)
@@ -1235,7 +1235,7 @@ public class ZarrTest {
   @Test
   public void testMinSizeThreshold() throws Exception {
     input = fake();
-    assertTool("--min-size", "30");
+    assertTool("--target-min-size", "30");
 
     ZarrGroup z = ZarrGroup.open(output.resolve("0").toString());
     List<Map<String, Object>> multiscales = (List<Map<String, Object>>)
@@ -1258,7 +1258,7 @@ public class ZarrTest {
   @Test
   public void testMinSizeAsymmetricExact() throws Exception {
     input = fake("sizeX", "1024");
-    assertTool("--min-size", "32");
+    assertTool("--target-min-size", "32");
 
     ZarrGroup z = ZarrGroup.open(output.resolve("0").toString());
     List<Map<String, Object>> multiscales = (List<Map<String, Object>>)
@@ -1281,7 +1281,7 @@ public class ZarrTest {
   @Test
   public void testMinSizeAsymmetricThreshold() throws Exception {
     input = fake("sizeY", "1024");
-    assertTool("--min-size", "30");
+    assertTool("--target-min-size", "30");
 
     ZarrGroup z = ZarrGroup.open(output.resolve("0").toString());
     List<Map<String, Object>> multiscales = (List<Map<String, Object>>)

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1207,7 +1207,7 @@ public class ZarrTest {
   }
 
   /**
-   * Convert an image to produce smaller resolution of XY dimensions 32x32.
+   * Convert an image to produce  a smallest resolution of dimensions 32x32.
    */
   @Test
   public void testMinSizeExact() throws Exception {
@@ -1230,7 +1230,7 @@ public class ZarrTest {
   }
 
   /**
-   * Convert an image to produce smaller resolution of XY dimensions 16x16.
+   * Convert an image to produce a smallest resolution of dimensions 16x16.
    */
   @Test
   public void testMinSizeThreshold() throws Exception {
@@ -1250,6 +1250,52 @@ public class ZarrTest {
     assertArrayEquals(new int[] {1, 1, 1, 512, 512}, array.getShape());
     array = z.openArray("5");
     assertArrayEquals(new int[] {1, 1, 1, 16, 16}, array.getShape());
+  }
+
+  /**
+   * Convert an image to produce a smallest resolution of dimensions 32x16.
+   */
+  @Test
+  public void testMinSizeAsymmetricExact() throws Exception {
+    input = fake("sizeX", "1024");
+    assertTool("--min-size", "32");
+
+    ZarrGroup z = ZarrGroup.open(output.resolve("0").toString());
+    List<Map<String, Object>> multiscales = (List<Map<String, Object>>)
+            z.getAttributes().get("multiscales");
+
+    Map<String, Object> multiscale = multiscales.get(0);
+    List<Map<String, Object>> datasets =
+              (List<Map<String, Object>>) multiscale.get("datasets");
+    assertEquals(datasets.size(), 6);
+
+    ZarrArray array = z.openArray("0");
+    assertArrayEquals(new int[] {1, 1, 1, 512, 1024}, array.getShape());
+    array = z.openArray("5");
+    assertArrayEquals(new int[] {1, 1, 1, 16, 32}, array.getShape());
+  }
+
+  /**
+   * Convert an image to produce a smallest resolution of dimensions 8x16.
+   */
+  @Test
+  public void testMinSizeAsymmetricThreshold() throws Exception {
+    input = fake("sizeY", "1024");
+    assertTool("--min-size", "30");
+
+    ZarrGroup z = ZarrGroup.open(output.resolve("0").toString());
+    List<Map<String, Object>> multiscales = (List<Map<String, Object>>)
+            z.getAttributes().get("multiscales");
+
+    Map<String, Object> multiscale = multiscales.get(0);
+    List<Map<String, Object>> datasets =
+              (List<Map<String, Object>>) multiscale.get("datasets");
+    assertEquals(datasets.size(), 7);
+
+    ZarrArray array = z.openArray("0");
+    assertArrayEquals(new int[] {1, 1, 1, 1024, 512}, array.getShape());
+    array = z.openArray("6");
+    assertArrayEquals(new int[] {1, 1, 1, 16, 8}, array.getShape());
   }
 
   private void checkPlateGroupLayout(Path root, int rowCount, int colCount,

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1222,11 +1222,11 @@ public class ZarrTest {
     List<Map<String, Object>> datasets =
               (List<Map<String, Object>>) multiscale.get("datasets");
 
-    String last_path = (String) datasets.get(datasets.size()  - 1).get("path");
-    ZarrArray last_array = z.openArray(last_path);
+    String lastPath = (String) datasets.get(datasets.size()  - 1).get("path");
+    ZarrArray lastArray = z.openArray(lastPath);
 
-    assert last_array.getShape()[0] < 32;
-    assert last_array.getShape()[1] < 32;
+    assert lastArray.getShape()[0] < 32;
+    assert lastArray.getShape()[1] < 32;
   }
 
   private void checkPlateGroupLayout(Path root, int rowCount, int colCount,

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1207,7 +1207,7 @@ public class ZarrTest {
   }
 
   /**
-   * Convert an image to produce smaller resolution of XY dimensions 32x32
+   * Convert an image to produce smaller resolution of XY dimensions 32x32.
    */
   @Test
   public void testMinSizeExact() throws Exception {
@@ -1230,7 +1230,7 @@ public class ZarrTest {
   }
 
   /**
-   * Convert an image to produce smaller resolution of XY dimensions 16x16
+   * Convert an image to produce smaller resolution of XY dimensions 16x16.
    */
   @Test
   public void testMinSizeThreshold() throws Exception {


### PR DESCRIPTION
The current implementation stops downsampling the image as soon as both X and Y dimensions are smaller than 256. In some cases, we want this cut-off values to be configurable.

This commit makes the minimal change by keeping the default as 256 but allowing to override it via command-line option.

Tests are also added to cover the min-size arguments with various scenarios