### PR TITLE
Fix plate detection to ignore empty plates

### DIFF
--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -869,6 +869,27 @@ public class ZarrTest {
   }
 
   /**
+   * Plate defined with no linked images.
+   */
+  @Test
+  public void testEmptyPlate() throws Exception {
+    input = getTestFile("empty-plate.ome.xml");
+    assertTool();
+
+    ZarrGroup z = ZarrGroup.open(output);
+
+    // Check dimensions and block size for consistency
+    // with non-HCS layout
+    ZarrArray series0 = z.openArray("0/0");
+    assertArrayEquals(new int[] {1, 1, 1, 4, 6}, series0.getShape());
+    assertArrayEquals(new int[] {1, 1, 1, 4, 6}, series0.getChunks());
+
+    // Check OME metadata to make sure the empty plate was preserved
+    OME ome = getOMEMetadata();
+    assertEquals(1, ome.sizeOfPlateList());
+  }
+
+  /**
    * 96 well plate with only well E6.
    */
   @Test

--- a/src/test/resources/com/glencoesoftware/bioformats2raw/test/empty-plate.ome.xml
+++ b/src/test/resources/com/glencoesoftware/bioformats2raw/test/empty-plate.ome.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                         http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+  <Plate
+     ID="Plate:1"
+     Name="Control Platedasd"
+     ColumnNamingConvention="letter"
+     RowNamingConvention="number"
+     Columns="12"
+     Rows="8"
+     >
+  </Plate>
+
+  <Image ID="Image:0" Name="6x6x1x8-swatch.tif">
+    <AcquisitionDate>2010-02-23T12:51:30</AcquisitionDate>
+    <Pixels DimensionOrder="XYCZT" ID="Pixels:0:0" PhysicalSizeX="10000.0"
+            PhysicalSizeY="10000.0" Type="uint8" SizeC="1" SizeT="1" SizeX="6" SizeY="4" SizeZ="1">
+      <Channel Color="-2147483648" ID="Channel:0"/>
+      <BinData BigEndian="false" Length="32"
+                   >/wCrzur//wB5oMPi/wBIbJO3AP8ePGCF</BinData>
+    </Pixels>
+  </Image>
+
+</OME>


### PR DESCRIPTION
HCS metadata will now only be written by default if there is at least one Plate, which contains at least one Well, which has at least one WellSample that links to an existing Image ID.  This means that empty plates will be ignored for the purposes of writing Zarr, but will be preserved in METADATA.ome.xml.

For datasets that have only empty/invalid plates, the default ```bioformats2raw``` behavior with this PR should match ```bioformats2raw --no-hcs``` without this PR.  No test (yet?) as creating an empty plate via fake files isn't possible.