### PR TITLE
Feature/improve docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+build
+*.class
+.git
+.gitignore
+.gradle
+.*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ ENV PATH="/opt/bioformats2raw/bin:${PATH}"
 
 USER 1000
 WORKDIR /opt/bioformats2raw
-CMD ["bioformats2raw"]
+ENTRYPOINT ["/opt/bioformats2raw/bin/bioformats2raw"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG BUILD_IMAGE=gradle:6.9-jdk8
 #
 FROM ${BUILD_IMAGE} as build
 USER root
-RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libzeroc-ice3.7-java libblosc1
+RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libblosc1
 RUN mkdir /bioformats2raw && chown 1000:1000 /bioformats2raw
 
 # Build all
@@ -32,7 +32,7 @@ FROM openjdk:8 as final
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update -y -q \
- && apt-get install -y --no-install-recommends -q libzeroc-ice3.7-java libblosc1 \
+ && apt-get install -y --no-install-recommends -q libblosc1 \
  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,18 +28,18 @@ RUN gradle build
 RUN cd build/distributions && rm bioformats2raw*tar && unzip bioformats2raw*zip && rm -rf bioformats2raw*zip
 
 
-
 FROM openjdk:8 as final
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update -y -q \
- && apt-get install -y -q libzeroc-ice3.7-java libblosc1 \
+ && apt-get install -y --no-install-recommends -q libzeroc-ice3.7-java libblosc1 \
  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
 USER root
 COPY --from=build /bioformats2raw/build/distributions/bioformats2raw* /opt/bioformats2raw
+ENV PATH="/opt/bioformats2raw/bin:${PATH}"
 
 USER 1000
 WORKDIR /opt/bioformats2raw
-ENTRYPOINT ["/opt/bioformats2raw/bin/bioformats2raw"]
+CMD ["bioformats2raw"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # Similarly, the BUILD_IMAGE argument can be overwritten
 # but this is generally not needed.
-ARG BUILD_IMAGE=gradle:6.2.1-jdk8
+ARG BUILD_IMAGE=gradle:6.9-jdk8
 
 #
 # Build phase: Use the gradle image for building.


### PR DESCRIPTION
This PR revises the Dockerfile generate a lighter yet complete Docker image that follows common entrypoint/cmd conventions.   

Image size is reduced by using a two-stage build, avoiding the installation of packages that don't seem to be required, and cleaning up temporary installation files.  The final image is based on the openjdk:8 Docker image rather than the gradle image.  The gradle version used for the build is bumped to 6.9 (seems to me that's the oldest still supported version).

The image has been tested converting a number of Mirax and SVS slides to raw format.

Changing the entrypoint changes the way one starts a container with the image.  Namely, the command `bioformats2raw` needs to be specified in the command line, i.e.:

    docker run -it --rm ilveroluca/bioformats2raw bioformats2raw bioformats2raw --log-level=INFO input.mrxs output.raw

