### PR TITLE
Fix OME-NGFF metadata when writing flattened layout

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1479,6 +1479,10 @@ public class Converter implements Callable<Void> {
     LOGGER.debug("setSeriesLevelMetadata({}, {})", series, resolutions);
     String resolutionString = String.format(
             scaleFormatString, getScaleFormatStringArgs(series, 0));
+    if (resolutionString.endsWith("/")) {
+      resolutionString = resolutionString.substring(
+        0, resolutionString.length() - 1);
+    }
     String seriesString = "";
     if (resolutionString.indexOf('/') >= 0) {
       seriesString = resolutionString.substring(0,

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -219,6 +219,9 @@ public class ZarrTest {
     assertTool("--scale-format-string", "%2$d");
     ZarrGroup series0 = ZarrGroup.open(output.toString());
     series0.openArray("0");
+    List<Map<String, Object>> multiscales = (List<Map<String, Object>>)
+            series0.getAttributes().get("multiscales");
+    assertEquals(1, multiscales.size());
   }
 
   /**

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -212,11 +212,14 @@ public class ZarrTest {
 
   /**
    * Test single directory scale format string.
+   *
+   * @param format scale format string
    */
-  @Test
-  public void testSingleDirectoryScaleFormat() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {"%2$d", "%2$d/"})
+  public void testSingleDirectoryScaleFormat(String format) throws Exception {
     input = fake();
-    assertTool("--scale-format-string", "%2$d");
+    assertTool("--scale-format-string", format);
     ZarrGroup series0 = ZarrGroup.open(output.toString());
     series0.openArray("0");
     List<Map<String, Object>> multiscales = (List<Map<String, Object>>)


### PR DESCRIPTION
See https://forum.image.sc/t/dropping-the-top-layer-in-ome-zarr-data-without-losing-multiscales-metadata/63286

As originally suggested in https://github.com/glencoesoftware/bioformats2raw/issues/108#issuecomment-887579778 and captured in the README, setting the `--scale-format-string` to `%2$d/` allows to flatten the hierarchy created `bioformats2raw` to match the layout of OME-NGFF multiscale images. Using `bioformat2raw 0.4.0`, this command results in the absence of the `multiscales` metadata from the top-level group:

```
(zarr_dev) [sbesson@pilot-zarr2-dev ~]$ bioformats2raw test.fake test.zarr --scale-format-string '%2$d/' &&  cat test.zarr/.zattrs
OpenJDK 64-Bit Server VM warning: You have loaded library /tmp/opencv_openpnp8729792479941275324/nu/pattern/opencv/linux/x86_64/libopencv_java342.so which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
{
  "bioformats2raw.layout" : 3
}
```

After investigation, this is due to the logic in https://github.com/glencoesoftware/bioformats2raw/blob/master/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java#L1483 which fails to handle this particular `resolutionString` and lead to the following resolution:

```
2022-02-15 09:50:46,281 [main] DEBUG c.g.bioformats2raw.Converter -   seriesString = 0
2022-02-15 09:50:46,281 [main] DEBUG c.g.bioformats2raw.Converter -   resolutionString = 0/
```

instead of 

```
2022-02-15 10:30:22,690 [main] DEBUG c.g.bioformats2raw.Converter -   seriesString = 
2022-02-15 10:30:22,690 [main] DEBUG c.g.bioformats2raw.Converter -   resolutionString = 0
```

As noted on the forum post, using the current release of the tool, dropping the trailing slash produces a different output which preservesx the top-level Zarr/OME-NGFF metadata. 

```
(zarr_dev) [sbesson@pilot-zarr2-dev ~]$ bioformats2raw test.fake test2.zarr --scale-format-string '%2$d' &&  cat test2.zarr/.zattrs
OpenJDK 64-Bit Server VM warning: You have loaded library /tmp/opencv_openpnp5978412340746156458/nu/pattern/opencv/linux/x86_64/libopencv_java342.so which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
{
  "multiscales" : [
    {
      "metadata" : {
        "method" : "loci.common.image.SimpleImageScaler",
        "version" : "Bio-Formats 6.8.0"
      },
      "datasets" : [
        {
          "path" : "0"
        },
        {
          "path" : "1"
        }
      ],
      "version" : "0.2"
    }
  ]
}
```

However, this value conflicts with the recommendation at the bottom of https://github.com/glencoesoftware/bioformats2raw/tree/v0.4.0#--scale-format-string.

At minimum 8fb26372b1fc2772123b098ec52acd3fcf741022 expands the existing unit test (without the trailing slash) to capture the current expectation for the second command and check the presence of a Zarr group with `multiscales` metadata.

This PR will need at least one extra commit but there are two options:

- either `%2$d` becomes the recommended format for this layout, update the README and review the warning about trailing slashes in the README
- or `Converter` will need updates to match the data generated by `%2$d/` and `%2$d`

@melissalinkert @chris-allan let me know what you are happy to support moving forward and I can push updates accordingly


