### PR TITLE
First try at scale transforms

### DIFF
--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -321,6 +321,44 @@ public class ZarrTest {
   }
 
   /**
+   * Test that physical sizes are saved in axes/transformations metadata.
+   */
+  @Test
+  public void testPhysicalSizes() throws Exception {
+    input = fake("physicalSizeX", "1.0mm",
+      "physicalSizeY", "0.5mm",
+      "physicalSizeZ", "2cm");
+    assertTool();
+
+    ZarrGroup z = ZarrGroup.open(output.resolve("0").toString());
+    List<Map<String, Object>> multiscales = (List<Map<String, Object>>)
+            z.getAttributes().get("multiscales");
+    assertEquals(1, multiscales.size());
+    Map<String, Object> multiscale = multiscales.get(0);
+    List<Map<String, Object>> axes =
+      (List<Map<String, Object>>) multiscale.get("axes");
+    checkAxes(axes, "TCZYX");
+
+    List<Map<String, Object>> datasets =
+      (List<Map<String, Object>>) multiscale.get("datasets");
+    assertEquals(2, datasets.size());
+
+    for (Map<String, Object> dataset : datasets) {
+      List<Map<String, Object>> transforms =
+        (List<Map<String, Object>>) dataset.get("transformations");
+      assertEquals(1, transforms.size());
+      Map<String, Object> scale = transforms.get(0);
+      assertEquals("scale", scale.get("type"));
+      List<Integer> axisIndices = (List<Integer>) scale.get("axisIndices");
+      List<Double> axisValues = (List<Double>) scale.get("scale");
+
+      assertEquals(axisIndices.size(), axisValues.size());
+      assertEquals(axisIndices, Arrays.asList(new Integer[] {2, 3, 4}));
+      assertEquals(axisValues, Arrays.asList(new Double[] {2.0, 0.5, 1.0}));
+    }
+  }
+
+  /**
    * Test using a different tile size from the default (1024).
    */
   @Test


### PR DESCRIPTION
See https://github.com/ome/ngff/pull/57, follow-up to #121.

The main idea is to preserve physical sizes in the Zarr metadata itself, so that downstream applications don't have to read those values from the OME-XML. There is an open question of what to do for subresolutions; OME-XML won't store any physical sizes for those, so we could omit or store a calculated value.

/cc @sbesson @dgault (since I can't add external reviewers)