### PR TITLE
Update jna to 5.10.0 for arm64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,9 @@ jobs:
       - name: Run commands
         run: |
           ./gradlew ${{ env.gradle_commands }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bioformats2raw
+          path: build/distributions/*.zip
+          retention-days: 30

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ configurations.all {
 }
 
 dependencies {
+    implementation 'net.java.dev.jna:jna:5.10.0'
     implementation 'ome:formats-gpl:6.8.0'
     implementation 'info.picocli:picocli:4.6.1'
     implementation 'com.univocity:univocity-parsers:2.8.4'


### PR DESCRIPTION
See https://github.com/ome/ZarrReader/issues/16

I expect this to be required for an arm64/aarch64 JDK on an M1 to pick up `libblosc.dylib`, see also #139.