### PR TITLE
MRXS: update how 2 channel fluorescence JPEG data is handled

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -273,7 +273,11 @@ public class MiraxReader extends FormatReader {
         TilePointer thisOffset = lookupTile(index, col, row, no / MAX_CHANNELS);
         if (thisOffset != null) {
           int channel = no % MAX_CHANNELS;
-          if (fluorescence && getSizeC() != 2) {
+          // 2 channel JPEG data needs to have the channel index inverted
+          // 2 channel JPEG-2000 data should not have the channel index inverted
+          if (fluorescence &&
+            (getSizeC() != 2 || format.get(index).equals("JPEG")))
+          {
             channel = MAX_CHANNELS - channel - 1;
           }
 


### PR DESCRIPTION
JPEG-2000 data with 2 channels is known to have the third stored channel as filler.
What little 2 channel JPEG data we have uses the first channel as filler instead.