### PR TITLE
Expand axes tests to check for correct units

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -55,11 +55,15 @@ import loci.formats.meta.IMetadata;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
 import loci.formats.services.OMEXMLServiceImpl;
+import ome.units.quantity.Length;
 import ome.units.quantity.Quantity;
+import ome.units.quantity.Time;
 import ome.xml.meta.OMEXMLMetadataRoot;
 import ome.xml.model.enums.DimensionOrder;
 import ome.xml.model.enums.EnumerationException;
 import ome.xml.model.enums.PixelType;
+import ome.xml.model.enums.UnitsLength;
+import ome.xml.model.enums.UnitsTime;
 import ome.xml.model.primitives.PositiveInteger;
 
 import org.perf4j.slf4j.Slf4JStopWatch;
@@ -1610,7 +1614,20 @@ public class Converter implements Callable<Void> {
       thisAxis.put("name", axis);
       thisAxis.put("type", type);
       if (scale != null) {
-        thisAxis.put("unit", scale.unit().getSymbol());
+        String symbol = scale.unit().getSymbol();
+        String unitName = null;
+        try {
+          if (scale instanceof Length) {
+            unitName = UnitsLength.fromString(symbol).name().toLowerCase();
+          }
+          else if (scale instanceof Time) {
+            unitName = UnitsTime.fromString(symbol).name().toLowerCase();
+          }
+        }
+        catch (EnumerationException e) {
+          LOGGER.warn("Could not identify unit '{}'", symbol);
+        }
+        thisAxis.put("unit", unitName);
       }
       axes.add(thisAxis);
     }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -349,7 +349,7 @@ public class ZarrTest {
    */
   @Test
   public void testPhysicalSizes() throws Exception {
-    input = fake("physicalSizeX", "1.0mm",
+    input = fake("physicalSizeX", "1.0Å",
       "physicalSizeY", "0.5mm",
       "physicalSizeZ", "2cm");
     assertTool();
@@ -362,7 +362,7 @@ public class ZarrTest {
     List<Map<String, Object>> axes =
       (List<Map<String, Object>>) multiscale.get("axes");
     checkAxes(axes, "TCZYX",
-      new String[] {null, null, "centimeter", "millimeter", "millimeter"});
+      new String[] {null, null, "centimeter", "millimeter", "angstrom"});
 
     List<Map<String, Object>> datasets =
       (List<Map<String, Object>>) multiscale.get("datasets");

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -270,7 +270,7 @@ public class ZarrTest {
 
     List<Map<String, Object>> axes =
       (List<Map<String, Object>>) multiscale.get("axes");
-    checkAxes(axes, "TCZYX");
+    checkAxes(axes, "TCZYX", null);
 
     for (int r=0; r<datasets.size(); r++) {
       Map<String, Object> dataset = datasets.get(r);
@@ -320,7 +320,7 @@ public class ZarrTest {
     Map<String, Object> multiscale = multiscales.get(0);
     List<Map<String, Object>> axes =
       (List<Map<String, Object>>) multiscale.get("axes");
-    checkAxes(axes, "TZCYX");
+    checkAxes(axes, "TZCYX", null);
   }
 
   /**
@@ -341,7 +341,7 @@ public class ZarrTest {
     Map<String, Object> multiscale = multiscales.get(0);
     List<Map<String, Object>> axes =
       (List<Map<String, Object>>) multiscale.get("axes");
-    checkAxes(axes, "TZCYX");
+    checkAxes(axes, "TZCYX", null);
   }
 
   /**
@@ -361,7 +361,7 @@ public class ZarrTest {
     Map<String, Object> multiscale = multiscales.get(0);
     List<Map<String, Object>> axes =
       (List<Map<String, Object>>) multiscale.get("axes");
-    checkAxes(axes, "TCZYX");
+    checkAxes(axes, "TCZYX", new String[] {null, null, "cm", "mm", "mm"});
 
     List<Map<String, Object>> datasets =
       (List<Map<String, Object>>) multiscale.get("datasets");
@@ -1618,12 +1618,17 @@ public class ZarrTest {
     }
   }
 
-  private void checkAxes(List<Map<String, Object>> axes, String order) {
+  private void checkAxes(List<Map<String, Object>> axes, String order,
+    String[] units)
+  {
     assertEquals(axes.size(), order.length());
     for (int i=0; i<axes.size(); i++) {
       String name = axes.get(i).get("name").toString();
       assertEquals(name, order.toLowerCase().substring(i, i + 1));
       assertTrue(axes.get(i).containsKey("type"));
+      if (units != null) {
+        assertEquals(axes.get(i).get("unit"), units[i]);
+      }
     }
   }
 

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -361,7 +361,8 @@ public class ZarrTest {
     Map<String, Object> multiscale = multiscales.get(0);
     List<Map<String, Object>> axes =
       (List<Map<String, Object>>) multiscale.get("axes");
-    checkAxes(axes, "TCZYX", new String[] {null, null, "cm", "mm", "mm"});
+    checkAxes(axes, "TCZYX",
+      new String[] {null, null, "centimeter", "millimeter", "millimeter"});
 
     List<Map<String, Object>> datasets =
       (List<Map<String, Object>>) multiscale.get("datasets");

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1629,6 +1629,9 @@ public class ZarrTest {
       if (units != null) {
         assertEquals(axes.get(i).get("unit"), units[i]);
       }
+      else {
+        assertTrue(!axes.get(i).containsKey("unit"));
+      }
     }
   }
 


### PR DESCRIPTION
Checks that units are (or aren't) written as expected.

@chris-allan noticed when reviewing #134 that the units written by bioformats2raw are valid OME units, but not valid units based on the list in https://ngff.openmicroscopy.org/latest/#axes-md. This isn't technically incorrect, but probably isn't setting a good example. Adding OME units to the spec is probably the easiest solution, but I assume we'll need to discuss.

/cc @sbesson, @joshmoore, @dgault 