### PR TITLE
Delete memo files by default

### DIFF
--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1544,7 +1544,7 @@ public class ZarrTest {
   /**
    * Check that --keep-memo-files works as expected.
    */
-  //@Test
+  @Test
   public void testMemoFiles() throws Exception {
     // make sure a memo file is created
     // by default the fake init time is too small
@@ -1556,13 +1556,13 @@ public class ZarrTest {
     assertTrue(memoFile.exists());
 
     // make sure the existing memo file is not deleted
-    assertTool();
+    assertTool("--overwrite");
     assertTrue(memoFile.exists());
 
     // now delete the memo file and make sure that
     // a clean conversion doesn't leave a memo file around
     memoFile.delete();
-    assertTool();
+    assertTool("--overwrite");
     assertFalse(memoFile.exists());
   }
 

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -32,6 +32,7 @@ import com.glencoesoftware.bioformats2raw.Downsampling;
 import loci.common.LogbackTools;
 import loci.common.services.ServiceFactory;
 import loci.formats.FormatTools;
+import loci.formats.Memoizer;
 import loci.formats.in.FakeReader;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
@@ -1538,6 +1539,31 @@ public class ZarrTest {
     assertArrayEquals(new int[] {1, 1, 1, 1024, 512}, array.getShape());
     array = z.openArray("6");
     assertArrayEquals(new int[] {1, 1, 1, 16, 8}, array.getShape());
+  }
+
+  /**
+   * Check that --keep-memo-files works as expected.
+   */
+  //@Test
+  public void testMemoFiles() throws Exception {
+    // make sure a memo file is created
+    // by default the fake init time is too small
+    input = fake("sleepInitFile", "1000");
+    assertTool("--debug", "--keep-memo-files");
+
+    Memoizer m = new Memoizer();
+    File memoFile = m.getMemoFile(input.toString());
+    assertTrue(memoFile.exists());
+
+    // make sure the existing memo file is not deleted
+    assertTool();
+    assertTrue(memoFile.exists());
+
+    // now delete the memo file and make sure that
+    // a clean conversion doesn't leave a memo file around
+    memoFile.delete();
+    assertTool();
+    assertFalse(memoFile.exists());
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/glencoesoftware/bioformats2raw/issues/136

There are 3 cases covered here:

- `--keep-memo-files` is used; no memo files will be deleted
- memo file is not created, either because a valid memo file existed before bioformats2raw was run or the initialization time was too short; no memo files will be deleted
- memo file was created and `--keep-memo-files` is *not* used; memo file will be deleted at the end of conversion

The test is turned off at the moment as I need to figure out a way to force memo file creation for fake files (see https://github.com/ome/bioformats/pull/3804).