### PR TITLE
MRXS: fix PNG tile support

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -298,6 +298,11 @@ public class MiraxReader extends FormatReader {
           if (tileBuf != null) {
             int channelIndex = channel * (tileBuf.length / MAX_CHANNELS);
 
+            // channels were separated during readTile
+            if (tileBuf.length == width * height * pixel) {
+              channelIndex = 0;
+            }
+
             // overlap is confined to the edges of the tile,
             // so we can copy directly
             for (int trow=0; trow<intersection.height; trow++) {


### PR DESCRIPTION
Fixes #124.

https://openslide.cs.cmu.edu/download/openslide-testdata/Mirax/Mirax2.2-4-PNG.zip reproduces the issue. Without this PR, attempting to convert `Mirax2.2-4-PNG.mrxs` should throw `ArrayIndexOutOfBoundsException` many times, as noted in #124. With this PR, the same conversion should succeed, and running raw2ometiff afterwards should produce an OME-TIFF that looks reasonable in QuPath/showinf.