### PR TITLE
Update jzarr to 0.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'ome:formats-gpl:6.9.1'
     implementation 'info.picocli:picocli:4.6.1'
     implementation 'com.univocity:univocity-parsers:2.8.4'
-    implementation 'com.bc.zarr:jzarr:0.3.3-gs-SNAPSHOT'
+    implementation 'com.bc.zarr:jzarr:0.3.5'
     // implementation 'org.carlspring.cloud.aws:s3fs-nio:1.0-SNAPSHOT'
     // implementation 'io.nextflow:nxf-s3fs:1.1.0'
     implementation 'org.lasersonlab:s3fs:2.2.3'

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -69,6 +69,7 @@ import org.slf4j.LoggerFactory;
 import com.bc.zarr.ArrayParams;
 import com.bc.zarr.CompressorFactory;
 import com.bc.zarr.DataType;
+import com.bc.zarr.DimensionSeparator;
 import com.bc.zarr.ZarrArray;
 import com.bc.zarr.ZarrGroup;
 import com.glencoesoftware.bioformats2raw.MiraxReader.TilePointer;
@@ -1217,7 +1218,7 @@ public class Converter implements Callable<Void> {
           .chunks(new int[] {1, 1, activeChunkDepth, activeTileHeight,
             activeTileWidth})
           .dataType(dataType)
-          .nested(nested)
+          .dimensionSeparator(getDimensionSeparator())
           .compressor(CompressorFactory.create(
               compressionType.toString(), compressionProperties));
       ZarrArray.create(getRootPath().resolve(resolutionString), arrayParams);
@@ -1851,6 +1852,10 @@ public class Converter implements Callable<Void> {
         throw new IllegalArgumentException("Unsupported pixel type: "
             + FormatTools.getPixelTypeString(type));
     }
+  }
+
+  private DimensionSeparator getDimensionSeparator() {
+    return nested ? DimensionSeparator.SLASH : DimensionSeparator.DOT;
   }
 
   private void checkOutputPaths() {

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -240,7 +240,12 @@ public class ZarrTest {
     Integer layout = (Integer)
         z.getAttributes().get("bioformats2raw.layout");
     ZarrArray series0 = ZarrGroup.open(output.resolve("0")).openArray("0");
-    assertTrue(series0.getNested());
+
+    // no getter for DimensionSeparator in ZarrArray
+    // check that the correct separator was used by checking
+    // that the expected first chunk file exists
+    assertTrue(output.resolve("0/0/0/0/0/0/0").toFile().exists());
+
     // Also ensure we're using the latest .zarray metadata
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode root = objectMapper.readTree(
@@ -878,6 +883,12 @@ public class ZarrTest {
   public void testNestedStorage(boolean nested) throws IOException {
     input = fake();
     assertTool(nested ? "--nested" : "--no-nested");
+    if (nested) {
+      assertTrue(output.resolve("0/0/0/0/0/0/0").toFile().exists());
+    }
+    else {
+      assertTrue(output.resolve("0/0/0.0.0.0.0").toFile().exists());
+    }
   }
 
   /**


### PR DESCRIPTION
Switches from GS snapshot to 0.3.5, which is the current latest version.

The API for specifying nested chunks is slightly different, so this isn't just a version bump. While the separator can easily be set when creating an array, there is no API method to get the array's separator after the fact. Tests here now check for the existence of the first chunk file (which has a hard-coded path), but we could do something like what the jzarr tests do instead:

https://github.com/bcdev/jzarr/blob/0.3.5/src/test/java/com/bc/zarr/ZarrArrayTest_dimensionSeparator.java#L94

raw2ometiff will need a similar treatment (started on https://github.com/glencoesoftware/raw2ometiff/compare/master...melissalinkert:jzarr-version?expand=1), but not until this is in a released version of bioformats2raw.