### PR TITLE
HCS well sample/image mapping

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
@@ -29,7 +29,7 @@ public class HCSIndex {
     for (int p=0; p<meta.getPlateCount(); p++) {
       for (int w=0; w<meta.getWellCount(p); w++) {
         for (int ws=0; ws<meta.getWellSampleCount(p, w); ws++) {
-          if (meta.getWellSampleIndex(p, w, ws).getValue() == series) {
+          if (meta.getWellSampleImageRef(p, w, ws) == meta.getImageID(series)) {
             plate = p;
             field = ws;
             wellRow = meta.getWellRow(p, w).getValue();

--- a/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
@@ -44,7 +44,7 @@ public class HCSIndex {
                   break;
                 }
               }
-              if (thePlateAcquisition >= 0) {
+              if (thePlateAcquisition != null) {
                 break;
               }
             }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java
@@ -29,7 +29,9 @@ public class HCSIndex {
     for (int p=0; p<meta.getPlateCount(); p++) {
       for (int w=0; w<meta.getWellCount(p); w++) {
         for (int ws=0; ws<meta.getWellSampleCount(p, w); ws++) {
-          if (meta.getWellSampleImageRef(p, w, ws) == meta.getImageID(series)) {
+          if (meta.getWellSampleImageRef(p, w, ws).equals(
+              meta.getImageID(series)))
+          {
             plate = p;
             field = ws;
             wellRow = meta.getWellRow(p, w).getValue();

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1245,7 +1245,7 @@ public class ZarrTest {
 
     int rowCount = 8;
     int colCount = 12;
-    int fieldCount = 2;
+    int fieldCount = 3;
 
     Map<String, List<String>> plateMap = new HashMap<String, List<String>>();
     plateMap.put("E", Arrays.asList("6"));
@@ -1286,6 +1286,7 @@ public class ZarrTest {
     Map<Integer, Integer> wellAcquisitions = new HashMap<Integer, Integer>();
     wellAcquisitions.put(0, 0);
     wellAcquisitions.put(1, 1);
+    wellAcquisitions.put(2, null);
     checkWell(wellGroup, fieldCount, wellAcquisitions);
   }
 

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -963,7 +963,11 @@ public class ZarrTest {
         String columnName = (String) column.get("name");
         ZarrGroup wellGroup = ZarrGroup.open(
             output.resolve(rowName).resolve(columnName));
-        checkWell(wellGroup, fieldCount, 0);
+        Map<Integer, Integer> wellAcquisitions =
+            new HashMap<Integer, Integer>();
+        wellAcquisitions.put(0, 0);
+        wellAcquisitions.put(1, 0);
+        checkWell(wellGroup, fieldCount, wellAcquisitions);
       }
     }
 
@@ -1022,7 +1026,8 @@ public class ZarrTest {
       assertEquals(rowName + "/" + colName, wellPath);
 
       ZarrGroup wellGroup = ZarrGroup.open(output.resolve(wellPath));
-      checkWell(wellGroup, fieldCount, null);
+      Map<Integer, Integer> wellAcquisitions = new HashMap<Integer, Integer>();
+      checkWell(wellGroup, fieldCount, wellAcquisitions);
     }
 
     // check OME metadata
@@ -1100,7 +1105,9 @@ public class ZarrTest {
 
     // check well metadata
     ZarrGroup wellGroup = ZarrGroup.open(output.resolve(wellPath));
-    checkWell(wellGroup, fieldCount, 0);
+    Map<Integer, Integer> wellAcquisitions = new HashMap<Integer, Integer>();
+    wellAcquisitions.put(0, 0);
+    checkWell(wellGroup, fieldCount, wellAcquisitions);
   }
 
   /**
@@ -1158,7 +1165,9 @@ public class ZarrTest {
     assertEquals(2, ((Number) well.get("rowIndex")).intValue());
     assertEquals(11, ((Number) well.get("columnIndex")).intValue());
     ZarrGroup wellGroup = ZarrGroup.open(output.resolve(wellPath));
-    checkWell(wellGroup, fieldCount, 0);
+    Map<Integer, Integer> wellAcquisitions = new HashMap<Integer, Integer>();
+    wellAcquisitions.put(0, 0);
+    checkWell(wellGroup, fieldCount, wellAcquisitions);
 
     well = wells.get(1);
     wellPath = (String) well.get("path");
@@ -1166,7 +1175,7 @@ public class ZarrTest {
     assertEquals(7, ((Number) well.get("rowIndex")).intValue());
     assertEquals(1, ((Number) well.get("columnIndex")).intValue());
     wellGroup = ZarrGroup.open(output.resolve(wellPath));
-    checkWell(wellGroup, fieldCount, 0);
+    checkWell(wellGroup, fieldCount, wellAcquisitions);
   }
 
   /**
@@ -1218,7 +1227,9 @@ public class ZarrTest {
       assertEquals(5, ((Number) well.get("rowIndex")).intValue());
       assertEquals(col, ((Number) well.get("columnIndex")).intValue());
       ZarrGroup wellGroup = ZarrGroup.open(output.resolve(wellPath));
-      checkWell(wellGroup, fieldCount, 0);
+      Map<Integer, Integer> wellAcquisitions = new HashMap<Integer, Integer>();
+      wellAcquisitions.put(0, 0);
+      checkWell(wellGroup, fieldCount, wellAcquisitions);
     }
   }
 
@@ -1597,8 +1608,8 @@ public class ZarrTest {
   }
 
   private void checkWell(
-      ZarrGroup wellGroup, int fieldCount, Integer acquisition)
-          throws IOException
+      ZarrGroup wellGroup, int fieldCount,
+      Map<Integer, Integer> wellAcquisitions) throws IOException
   {
     Map<String, Object> well =
         (Map<String, Object>) wellGroup.getAttributes().get("well");
@@ -1609,6 +1620,7 @@ public class ZarrTest {
     for (int i=0; i<fieldCount; i++) {
       Map<String, Object> field = images.get(i);
       assertEquals(field.get("path"), String.valueOf(i));
+      Integer acquisition = wellAcquisitions.getOrDefault(i, null);
       if (acquisition == null) {
         assertFalse(field.containsKey("acquisition"));
       }

--- a/src/test/resources/com/glencoesoftware/bioformats2raw/test/E6-only-two-acqs.xml
+++ b/src/test/resources/com/glencoesoftware/bioformats2raw/test/E6-only-two-acqs.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Creator="OME Bio-Formats 6.6.1-SNAPSHOT" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+   <Plate ColumnNamingConvention="number" Columns="12" ExternalIdentifier="External Identifier" ID="Plate:0" Name="Plate Name 0" RowNamingConvention="letter" Rows="8" Status="Plate status" WellOriginX="0.0" WellOriginXUnit="µm" WellOriginY="1.0" WellOriginYUnit="µm">
+      <Description>
+         Plate 0 of 1
+      </Description>
+      <Well Color="255" Column="5" ExternalDescription="External Description" ExternalIdentifier="External Identifier" ID="Well:0_0_0_0" Row="4" Type="Transfection: done">
+         <WellSample ID="WellSample:0_0_0_0_0_0" Index="1" PositionX="0.0" PositionXUnit="reference frame" PositionY="1.0" PositionYUnit="reference frame" Timepoint="2006-05-04T18:13:51">
+            <ImageRef ID="Image:0"/>
+         </WellSample>
+         <WellSample ID="WellSample:0_0_0_0_0_1" Index="2" PositionX="0.0" PositionXUnit="reference frame" PositionY="1.0" PositionYUnit="reference frame" Timepoint="2006-05-04T19:13:51">
+            <ImageRef ID="Image:1"/>
+         </WellSample>
+      </Well>
+      <PlateAcquisition EndTime="2006-05-04T18:13:51" ID="PlateAcquisition:0" Name="PlateAcquisition Name 0" StartTime="2006-05-04T18:13:51">
+         <Description>
+            PlateAcquisition 0 of 1
+         </Description>
+         <WellSampleRef ID="WellSample:0_0_0_0_0_0"/>
+      </PlateAcquisition>
+      <PlateAcquisition EndTime="2006-05-04T19:13:51" ID="PlateAcquisition:1" Name="PlateAcquisition Name 1" StartTime="2006-05-04T19:13:51">
+         <Description>
+            PlateAcquisition 0 of 1
+         </Description>
+         <WellSampleRef ID="WellSample:0_0_0_0_0_1"/>
+      </PlateAcquisition>
+   </Plate>
+   <Image ID="Image:0" Name="test">
+      <Description>
+         Image Description 0
+      </Description>
+      <Pixels BigEndian="false" DimensionOrder="XYZCT" ID="Pixels:0" Interleaved="false" PhysicalSizeX="1.0" PhysicalSizeXUnit="µm" PhysicalSizeY="1.0" PhysicalSizeYUnit="µm" PhysicalSizeZ="1.0" PhysicalSizeZUnit="µm" SignificantBits="8" SizeC="1" SizeT="1" SizeX="2" SizeY="2" SizeZ="1" Type="uint8">
+         <Channel AcquisitionMode="FluorescenceLifetime" Color="1687603455" ContrastMethod="Brightfield" EmissionWavelength="300.3" EmissionWavelengthUnit="nm" ExcitationWavelength="400.3" ExcitationWavelengthUnit="nm" Fluor="Fluor" ID="Channel:0:0" IlluminationType="Oblique" NDFilter="1.0" Name="Name" PinholeSize="0.5" PinholeSizeUnit="µm" PockelCellSetting="0" SamplesPerPixel="1"/>
+         <Plane DeltaT="0.1" DeltaTUnit="s" ExposureTime="10.0" ExposureTimeUnit="s" PositionX="1.0" PositionXUnit="reference frame" PositionY="1.0" PositionYUnit="reference frame" PositionZ="1.0" PositionZUnit="reference frame" TheC="0" TheT="0" TheZ="0"/>
+         <BinData xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" Length="4" BigEndian="false">AAAAAA==</BinData>
+      </Pixels>
+   </Image>
+   <Image ID="Image:1" Name="test">
+      <Description>
+         Image Description 0
+      </Description>
+      <Pixels BigEndian="false" DimensionOrder="XYZCT" ID="Pixels:0" Interleaved="false" PhysicalSizeX="1.0" PhysicalSizeXUnit="µm" PhysicalSizeY="1.0" PhysicalSizeYUnit="µm" PhysicalSizeZ="1.0" PhysicalSizeZUnit="µm" SignificantBits="8" SizeC="1" SizeT="1" SizeX="2" SizeY="2" SizeZ="1" Type="uint8">
+         <Channel AcquisitionMode="FluorescenceLifetime" Color="1687603455" ContrastMethod="Brightfield" EmissionWavelength="300.3" EmissionWavelengthUnit="nm" ExcitationWavelength="400.3" ExcitationWavelengthUnit="nm" Fluor="Fluor" ID="Channel:0:0" IlluminationType="Oblique" NDFilter="1.0" Name="Name" PinholeSize="0.5" PinholeSizeUnit="µm" PockelCellSetting="0" SamplesPerPixel="1"/>
+         <Plane DeltaT="0.1" DeltaTUnit="s" ExposureTime="10.0" ExposureTimeUnit="s" PositionX="1.0" PositionXUnit="reference frame" PositionY="1.0" PositionYUnit="reference frame" PositionZ="1.0" PositionZUnit="reference frame" TheC="0" TheT="0" TheZ="0"/>
+         <BinData xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" Length="4" BigEndian="false">AAAAAA==</BinData>
+      </Pixels>
+   </Image>
+</OME>

--- a/src/test/resources/com/glencoesoftware/bioformats2raw/test/E6-only-two-acqs.xml
+++ b/src/test/resources/com/glencoesoftware/bioformats2raw/test/E6-only-two-acqs.xml
@@ -11,6 +11,9 @@
          <WellSample ID="WellSample:0_0_0_0_0_1" Index="2" PositionX="0.0" PositionXUnit="reference frame" PositionY="1.0" PositionYUnit="reference frame" Timepoint="2006-05-04T19:13:51">
             <ImageRef ID="Image:1"/>
          </WellSample>
+         <WellSample ID="WellSample:0_0_0_0_0_2" Index="3" PositionX="0.0" PositionXUnit="reference frame" PositionY="1.0" PositionYUnit="reference frame" Timepoint="2006-05-04T20:13:51">
+            <ImageRef ID="Image:2"/>
+         </WellSample>
       </Well>
       <PlateAcquisition EndTime="2006-05-04T18:13:51" ID="PlateAcquisition:0" Name="PlateAcquisition Name 0" StartTime="2006-05-04T18:13:51">
          <Description>
@@ -39,8 +42,18 @@
       <Description>
          Image Description 0
       </Description>
-      <Pixels BigEndian="false" DimensionOrder="XYZCT" ID="Pixels:0" Interleaved="false" PhysicalSizeX="1.0" PhysicalSizeXUnit="µm" PhysicalSizeY="1.0" PhysicalSizeYUnit="µm" PhysicalSizeZ="1.0" PhysicalSizeZUnit="µm" SignificantBits="8" SizeC="1" SizeT="1" SizeX="2" SizeY="2" SizeZ="1" Type="uint8">
-         <Channel AcquisitionMode="FluorescenceLifetime" Color="1687603455" ContrastMethod="Brightfield" EmissionWavelength="300.3" EmissionWavelengthUnit="nm" ExcitationWavelength="400.3" ExcitationWavelengthUnit="nm" Fluor="Fluor" ID="Channel:0:0" IlluminationType="Oblique" NDFilter="1.0" Name="Name" PinholeSize="0.5" PinholeSizeUnit="µm" PockelCellSetting="0" SamplesPerPixel="1"/>
+      <Pixels BigEndian="false" DimensionOrder="XYZCT" ID="Pixels:1" Interleaved="false" PhysicalSizeX="1.0" PhysicalSizeXUnit="µm" PhysicalSizeY="1.0" PhysicalSizeYUnit="µm" PhysicalSizeZ="1.0" PhysicalSizeZUnit="µm" SignificantBits="8" SizeC="1" SizeT="1" SizeX="2" SizeY="2" SizeZ="1" Type="uint8">
+         <Channel AcquisitionMode="FluorescenceLifetime" Color="1687603455" ContrastMethod="Brightfield" EmissionWavelength="300.3" EmissionWavelengthUnit="nm" ExcitationWavelength="400.3" ExcitationWavelengthUnit="nm" Fluor="Fluor" ID="Channel:1:0" IlluminationType="Oblique" NDFilter="1.0" Name="Name" PinholeSize="0.5" PinholeSizeUnit="µm" PockelCellSetting="0" SamplesPerPixel="1"/>
+         <Plane DeltaT="0.1" DeltaTUnit="s" ExposureTime="10.0" ExposureTimeUnit="s" PositionX="1.0" PositionXUnit="reference frame" PositionY="1.0" PositionYUnit="reference frame" PositionZ="1.0" PositionZUnit="reference frame" TheC="0" TheT="0" TheZ="0"/>
+         <BinData xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" Length="4" BigEndian="false">AAAAAA==</BinData>
+      </Pixels>
+   </Image>
+   <Image ID="Image:2" Name="test">
+      <Description>
+         Image Description 0
+      </Description>
+      <Pixels BigEndian="false" DimensionOrder="XYZCT" ID="Pixels:2" Interleaved="false" PhysicalSizeX="1.0" PhysicalSizeXUnit="µm" PhysicalSizeY="1.0" PhysicalSizeYUnit="µm" PhysicalSizeZ="1.0" PhysicalSizeZUnit="µm" SignificantBits="8" SizeC="1" SizeT="1" SizeX="2" SizeY="2" SizeZ="1" Type="uint8">
+         <Channel AcquisitionMode="FluorescenceLifetime" Color="1687603455" ContrastMethod="Brightfield" EmissionWavelength="300.3" EmissionWavelengthUnit="nm" ExcitationWavelength="400.3" ExcitationWavelengthUnit="nm" Fluor="Fluor" ID="Channel:2:0" IlluminationType="Oblique" NDFilter="1.0" Name="Name" PinholeSize="0.5" PinholeSizeUnit="µm" PockelCellSetting="0" SamplesPerPixel="1"/>
          <Plane DeltaT="0.1" DeltaTUnit="s" ExposureTime="10.0" ExposureTimeUnit="s" PositionX="1.0" PositionXUnit="reference frame" PositionY="1.0" PositionYUnit="reference frame" PositionZ="1.0" PositionZUnit="reference frame" TheC="0" TheT="0" TheZ="0"/>
          <BinData xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" Length="4" BigEndian="false">AAAAAA==</BinData>
       </Pixels>


### PR DESCRIPTION
Discovered while investigating https://forum.image.sc/t/ome-zarr-conversion-tool/62234/29

The current logic for assiging well samples to series is based on `WellSample.Index` and the assumption this corresponds to the series index. For most Bio-Formats HCS readers, the reader generates and populates this metadata and this assumption holds.
Looking at the specification, the [WellSample.Index](https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#WellSample_Index) is defined more liberally as there is no clear expectation is should map to the `Image` order, indices do not need to start at `0` and gaps are allowed. Examples of such indexing can be found in the official OME-XML/OME-TIFF samples like the [plate-companion OME-TIFF](https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/plate-companion/hcs.companion.ome)  or [one-screen-one-plate-four-wells OME-XML](https://downloads.openmicroscopy.org/images/OME-XML/2016-06/one-screen-one-plate-four-wells.ome.xml) samples.

With bioformats2raw 0.4.0, converting both samples will create a `-1/-1/-1` Zarr hierarchy as described in the thread above. Using the current `HEAD` of this repository, the converter will error  while trying to assign a series to a well sample in https://github.com/glencoesoftware/bioformats2raw/blob/8eb4aae1017e5c5a642a0791e8d0ae60d1d81bed/src/main/java/com/glencoesoftware/bioformats2raw/HCSIndex.java#L57-L58.

878a586adff3d08c0eebff30b43d3f82d808e4de proposes to solve this issue by replacing the index-based check by a reference based check using `WellSample.ImageRef` and `Image.ID`.
7297dd2434d4b4c00ddf97fe71c999535730bf2c fixes a secondary issue that arises if multiple `PlateAcquisition` elements are defined.

The two OME-XML and OME-TIFF samples mentioned above can be used to test this PR:
- the conversion command should complete successfully
- the conversion should contain no more Zarr groups named `-1`
- for `one-screen-one-plate-four-wells.ome.xml`, two `acquisitions` elements should be defined in the top-level `.zattrs` and be referenced in the well attributes
