### PR TITLE
Explicitly forbid converting datasets with multiple plates

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -562,6 +562,12 @@ public class Converter implements Callable<Void> {
 
         if (!noHCS) {
           noHCS = !hasValidPlate(meta);
+          int plateCount = meta.getPlateCount();
+          if (!noHCS && plateCount > 1) {
+            throw new IllegalArgumentException(
+              "Found " + plateCount + " plates; only one can be converted. " +
+              "Use --no-hcs to as a work-around.");
+          }
         }
         else {
           ((OMEXMLMetadata) meta).resolveReferences();

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -905,6 +905,19 @@ public class ZarrTest {
   }
 
   /**
+   * Make sure conversion fails when multiple plates are present.
+   */
+  @Test
+  public void testMultiPlates() throws Exception {
+    input = fake(
+      "plates", "2", "plateAcqs", "1",
+      "plateRows", "2", "plateCols", "3", "fields", "2");
+    assertThrows(ExecutionException.class, () -> {
+      assertTool();
+    });
+  }
+
+  /**
    * Convert a plate with default options.
    * The output should be compliant with OME Zarr HCS.
    */


### PR DESCRIPTION
...unless `--no-hcs` is used.

Part of the same discussion as https://github.com/glencoesoftware/bioformats2raw/pull/149 (/cc @sbesson, @joshmoore, @dgault). The majority of HCS readers only populate one `Plate`, but OME-XML/OME-TIFF can have multiple plates (e.g. https://github.com/ome/ome-model/blob/master/specification/samples/2016-06/two-screens-two-plates-four-wells.ome.xml). It's not completely clear how we should handle that case, so for now throwing an exception prevents unusable data from being written.
 