### PR TITLE
Add group path to series index mapping in root attributes

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -682,7 +682,7 @@ public class Converter implements Callable<Void> {
         // series (OME-XML Image) index
         // using the index as the key would mean that the index is stored
         // as a string instead of an integer
-        Map<String, Integer> groupMap = new HashMap<String, Integer>();
+        List<String> groups = new ArrayList<String>();
         for (Integer index : seriesList) {
           String resolutionString = String.format(
                   scaleFormatString, getScaleFormatStringArgs(index, 0));
@@ -691,9 +691,9 @@ public class Converter implements Callable<Void> {
             seriesString = resolutionString.substring(0,
                 resolutionString.lastIndexOf('/'));
           }
-          groupMap.put(seriesString, index);
+          groups.add(seriesString);
         }
-        attributes.put("series", groupMap);
+        attributes.put("series", groups);
 
         root.writeAttributes(attributes);
       }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -671,6 +671,13 @@ public class Converter implements Callable<Void> {
         Map<String, Object> attributes = new HashMap<String, Object>();
         attributes.put("bioformats2raw.layout", LAYOUT);
 
+        root.writeAttributes(attributes);
+      }
+      if (!noOMEMeta) {
+        Path metadataPath = getRootPath().resolve("OME");
+        final ZarrGroup root = ZarrGroup.create(metadataPath);
+        Map<String, Object> attributes = new HashMap<String, Object>();
+
         // record the path to each series (multiscales) and the corresponding
         // series (OME-XML Image) index
         // using the index as the key would mean that the index is stored
@@ -686,7 +693,7 @@ public class Converter implements Callable<Void> {
           }
           groupMap.put(seriesString, index);
         }
-        attributes.put("groups", groupMap);
+        attributes.put("series", groupMap);
 
         root.writeAttributes(attributes);
       }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -213,11 +213,10 @@ public class ZarrTest {
 
     Path omePath = output.resolve("OME");
     ZarrGroup z = ZarrGroup.open(omePath.toString());
-    Map<String, Integer> groupMap =
-      (Map<String, Integer>) z.getAttributes().get("series");
+    List<String> groupMap = (List<String>) z.getAttributes().get("series");
     assertEquals(groupMap.size(), 2);
-    assertEquals(groupMap.get("abc/888/0"), 0);
-    assertEquals(groupMap.get("ghi/999/1"), 1);
+    assertEquals(groupMap.get(0), "abc/888/0");
+    assertEquals(groupMap.get(1), "ghi/999/1");
   }
 
   /**
@@ -251,10 +250,10 @@ public class ZarrTest {
 
     Path omePath = output.resolve("OME");
     ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
-    Map<String, Integer> groupMap =
-      (Map<String, Integer>) omeGroup.getAttributes().get("series");
+    List<String> groupMap =
+      (List<String>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 1);
-    assertEquals(groupMap.get("0"), 0);
+    assertEquals(groupMap.get(0), "0");
 
     ZarrArray series0 = ZarrGroup.open(output.resolve("0")).openArray("0");
 
@@ -446,11 +445,11 @@ public class ZarrTest {
 
     Path omePath = output.resolve("OME");
     ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
-    Map<String, Integer> groupMap =
-      (Map<String, Integer>) omeGroup.getAttributes().get("series");
+    List<String> groupMap =
+      (List<String>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 2);
-    assertEquals(groupMap.get("0"), 0);
-    assertEquals(groupMap.get("1"), 1);
+    assertEquals(groupMap.get(0), "0");
+    assertEquals(groupMap.get(1), "1");
 
     // Check series 0 dimensions and special pixels
     ZarrArray series0 = z.openArray("0/0");
@@ -488,10 +487,13 @@ public class ZarrTest {
 
     Path omePath = output.resolve("OME");
     ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
-    Map<String, Integer> groupMap =
-      (Map<String, Integer>) omeGroup.getAttributes().get("series");
+    List<String> groupMap =
+      (List<String>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 1);
-    assertEquals(groupMap.get("0"), 0);
+    assertEquals(groupMap.get(0), "0");
+
+    OME ome = getOMEMetadata();
+    assertEquals(1, ome.sizeOfImageList());
 
     // Check series 0 dimensions and special pixels
     ZarrArray series0 = z.openArray("0/0");
@@ -522,10 +524,13 @@ public class ZarrTest {
 
     Path omePath = output.resolve("OME");
     ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
-    Map<String, Integer> groupMap =
-      (Map<String, Integer>) omeGroup.getAttributes().get("series");
+    List<String> groupMap =
+      (List<String>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 1);
-    assertEquals(groupMap.get("0"), 1);
+    assertEquals(groupMap.get(0), "0");
+
+    OME ome = getOMEMetadata();
+    assertEquals(1, ome.sizeOfImageList());
 
     // Check series 1 dimensions and special pixels
     ZarrArray series0 = z.openArray("0/0");
@@ -556,10 +561,13 @@ public class ZarrTest {
 
     Path omePath = output.resolve("OME");
     ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
-    Map<String, Integer> groupMap =
-      (Map<String, Integer>) omeGroup.getAttributes().get("series");
+    List<String> groupMap =
+      (List<String>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 1);
-    assertEquals(groupMap.get("0"), 1);
+    assertEquals(groupMap.get(0), "0");
+
+    OME ome = getOMEMetadata();
+    assertEquals(1, ome.sizeOfImageList());
 
     // Check series 1 dimensions and special pixels
     ZarrArray series0 = z.openArray("0/0");
@@ -959,11 +967,11 @@ public class ZarrTest {
 
     Path omePath = output.resolve("OME");
     ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
-    Map<String, Integer> groupMap =
-      (Map<String, Integer>) omeGroup.getAttributes().get("series");
+    List<String> groupMap =
+      (List<String>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 12);
     for (int i=0; i<12; i++) {
-      assertEquals(groupMap.get(String.valueOf(i)), i);
+      assertEquals(groupMap.get(i), String.valueOf(i));
     }
 
     // Check dimensions and block size
@@ -1010,15 +1018,15 @@ public class ZarrTest {
 
     Path omePath = output.resolve("OME");
     ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
-    Map<String, Integer> groupMap =
-      (Map<String, Integer>) omeGroup.getAttributes().get("series");
+    List<String> groupMap =
+      (List<String>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 12);
     int index = 0;
     for (int r=0; r<rowCount; r++) {
       for (int c=0; c<colCount; c++) {
         for (int f=0; f<fieldCount; f++) {
           String groupPath = (char) (r + 'A') + "/" + (c + 1) + "/" + f;
-          assertEquals(groupMap.get(groupPath), index++);
+          assertEquals(groupMap.get(index++), groupPath);
         }
       }
     }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -210,6 +210,13 @@ public class ZarrTest {
     series0.openArray("0");
     series0 = ZarrGroup.open(output.resolve("ghi/999/1").toString());
     series0.openArray("0");
+
+    ZarrGroup z = ZarrGroup.open(output.toString());
+    Map<String, Integer> groupMap =
+      (Map<String, Integer>) z.getAttributes().get("groups");
+    assertEquals(groupMap.size(), 2);
+    assertEquals(groupMap.get("abc/888/0"), 0);
+    assertEquals(groupMap.get("ghi/999/1"), 1);
   }
 
   /**
@@ -240,6 +247,12 @@ public class ZarrTest {
     ZarrGroup z = ZarrGroup.open(output.toString());
     Integer layout = (Integer)
         z.getAttributes().get("bioformats2raw.layout");
+
+    Map<String, Integer> groupMap =
+      (Map<String, Integer>) z.getAttributes().get("groups");
+    assertEquals(groupMap.size(), 1);
+    assertEquals(groupMap.get("0"), 0);
+
     ZarrArray series0 = ZarrGroup.open(output.resolve("0")).openArray("0");
 
     // no getter for DimensionSeparator in ZarrArray
@@ -428,6 +441,12 @@ public class ZarrTest {
     assertTool();
     ZarrGroup z = ZarrGroup.open(output.toString());
 
+    Map<String, Integer> groupMap =
+      (Map<String, Integer>) z.getAttributes().get("groups");
+    assertEquals(groupMap.size(), 2);
+    assertEquals(groupMap.get("0"), 0);
+    assertEquals(groupMap.get("1"), 1);
+
     // Check series 0 dimensions and special pixels
     ZarrArray series0 = z.openArray("0/0");
     assertArrayEquals(new int[] {1, 1, 1, 512, 512}, series0.getShape());
@@ -461,6 +480,10 @@ public class ZarrTest {
     input = fake("series", "2");
     assertTool("-s", "0");
     ZarrGroup z = ZarrGroup.open(output.toString());
+    Map<String, Integer> groupMap =
+      (Map<String, Integer>) z.getAttributes().get("groups");
+    assertEquals(groupMap.size(), 1);
+    assertEquals(groupMap.get("0"), 0);
 
     // Check series 0 dimensions and special pixels
     ZarrArray series0 = z.openArray("0/0");
@@ -488,6 +511,10 @@ public class ZarrTest {
     input = fake("series", "2");
     assertTool("-s", "1");
     ZarrGroup z = ZarrGroup.open(output.toString());
+    Map<String, Integer> groupMap =
+      (Map<String, Integer>) z.getAttributes().get("groups");
+    assertEquals(groupMap.size(), 1);
+    assertEquals(groupMap.get("0"), 1);
 
     // Check series 1 dimensions and special pixels
     ZarrArray series0 = z.openArray("0/0");
@@ -515,6 +542,10 @@ public class ZarrTest {
     input = fake("series", "3");
     assertTool("-s", "1");
     ZarrGroup z = ZarrGroup.open(output.toString());
+    Map<String, Integer> groupMap =
+      (Map<String, Integer>) z.getAttributes().get("groups");
+    assertEquals(groupMap.size(), 1);
+    assertEquals(groupMap.get("0"), 1);
 
     // Check series 1 dimensions and special pixels
     ZarrArray series0 = z.openArray("0/0");
@@ -911,6 +942,12 @@ public class ZarrTest {
     assertTool("--no-hcs");
 
     ZarrGroup z = ZarrGroup.open(output);
+    Map<String, Integer> groupMap =
+      (Map<String, Integer>) z.getAttributes().get("groups");
+    assertEquals(groupMap.size(), 12);
+    for (int i=0; i<12; i++) {
+      assertEquals(groupMap.get(String.valueOf(i)), i);
+    }
 
     // Check dimensions and block size
     ZarrArray series0 = z.openArray("0/0");
@@ -952,6 +989,20 @@ public class ZarrTest {
     int rowCount = 2;
     int colCount = 3;
     int fieldCount = 2;
+
+    Map<String, Integer> groupMap =
+      (Map<String, Integer>) z.getAttributes().get("groups");
+    assertEquals(groupMap.size(), 12);
+    int index = 0;
+    for (int r=0; r<rowCount; r++) {
+      for (int c=0; c<colCount; c++) {
+        for (int f=0; f<fieldCount; f++) {
+          String groupPath = (char) (r + 'A') + "/" + (c + 1) + "/" + f;
+          assertEquals(groupMap.get(groupPath), index++);
+        }
+      }
+    }
+
     Map<String, List<String>> plateMap = new HashMap<String, List<String>>();
     plateMap.put("A", Arrays.asList("1", "2", "3"));
     plateMap.put("B", Arrays.asList("1", "2", "3"));

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -211,9 +211,10 @@ public class ZarrTest {
     series0 = ZarrGroup.open(output.resolve("ghi/999/1").toString());
     series0.openArray("0");
 
-    ZarrGroup z = ZarrGroup.open(output.toString());
+    Path omePath = output.resolve("OME");
+    ZarrGroup z = ZarrGroup.open(omePath.toString());
     Map<String, Integer> groupMap =
-      (Map<String, Integer>) z.getAttributes().get("groups");
+      (Map<String, Integer>) z.getAttributes().get("series");
     assertEquals(groupMap.size(), 2);
     assertEquals(groupMap.get("abc/888/0"), 0);
     assertEquals(groupMap.get("ghi/999/1"), 1);
@@ -248,8 +249,10 @@ public class ZarrTest {
     Integer layout = (Integer)
         z.getAttributes().get("bioformats2raw.layout");
 
+    Path omePath = output.resolve("OME");
+    ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
     Map<String, Integer> groupMap =
-      (Map<String, Integer>) z.getAttributes().get("groups");
+      (Map<String, Integer>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 1);
     assertEquals(groupMap.get("0"), 0);
 
@@ -441,8 +444,10 @@ public class ZarrTest {
     assertTool();
     ZarrGroup z = ZarrGroup.open(output.toString());
 
+    Path omePath = output.resolve("OME");
+    ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
     Map<String, Integer> groupMap =
-      (Map<String, Integer>) z.getAttributes().get("groups");
+      (Map<String, Integer>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 2);
     assertEquals(groupMap.get("0"), 0);
     assertEquals(groupMap.get("1"), 1);
@@ -480,8 +485,11 @@ public class ZarrTest {
     input = fake("series", "2");
     assertTool("-s", "0");
     ZarrGroup z = ZarrGroup.open(output.toString());
+
+    Path omePath = output.resolve("OME");
+    ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
     Map<String, Integer> groupMap =
-      (Map<String, Integer>) z.getAttributes().get("groups");
+      (Map<String, Integer>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 1);
     assertEquals(groupMap.get("0"), 0);
 
@@ -511,8 +519,11 @@ public class ZarrTest {
     input = fake("series", "2");
     assertTool("-s", "1");
     ZarrGroup z = ZarrGroup.open(output.toString());
+
+    Path omePath = output.resolve("OME");
+    ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
     Map<String, Integer> groupMap =
-      (Map<String, Integer>) z.getAttributes().get("groups");
+      (Map<String, Integer>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 1);
     assertEquals(groupMap.get("0"), 1);
 
@@ -542,8 +553,11 @@ public class ZarrTest {
     input = fake("series", "3");
     assertTool("-s", "1");
     ZarrGroup z = ZarrGroup.open(output.toString());
+
+    Path omePath = output.resolve("OME");
+    ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
     Map<String, Integer> groupMap =
-      (Map<String, Integer>) z.getAttributes().get("groups");
+      (Map<String, Integer>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 1);
     assertEquals(groupMap.get("0"), 1);
 
@@ -942,8 +956,11 @@ public class ZarrTest {
     assertTool("--no-hcs");
 
     ZarrGroup z = ZarrGroup.open(output);
+
+    Path omePath = output.resolve("OME");
+    ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
     Map<String, Integer> groupMap =
-      (Map<String, Integer>) z.getAttributes().get("groups");
+      (Map<String, Integer>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 12);
     for (int i=0; i<12; i++) {
       assertEquals(groupMap.get(String.valueOf(i)), i);
@@ -953,7 +970,8 @@ public class ZarrTest {
     ZarrArray series0 = z.openArray("0/0");
     assertArrayEquals(new int[] {1, 1, 1, 512, 512}, series0.getShape());
     assertArrayEquals(new int[] {1, 1, 1, 512, 512}, series0.getChunks());
-    assertEquals(12, z.getGroupKeys().size());
+    // 12 series + OME group
+    assertEquals(13, z.getGroupKeys().size());
 
     // Check OME metadata
     OME ome = getOMEMetadata();
@@ -990,8 +1008,10 @@ public class ZarrTest {
     int colCount = 3;
     int fieldCount = 2;
 
+    Path omePath = output.resolve("OME");
+    ZarrGroup omeGroup = ZarrGroup.open(omePath.toString());
     Map<String, Integer> groupMap =
-      (Map<String, Integer>) z.getAttributes().get("groups");
+      (Map<String, Integer>) omeGroup.getAttributes().get("series");
     assertEquals(groupMap.size(), 12);
     int index = 0;
     for (int r=0; r<rowCount; r++) {
@@ -1441,6 +1461,8 @@ public class ZarrTest {
 
     assertTrue(!Files.exists(
       output.resolve("OME").resolve("METADATA.ome.xml")));
+    assertTrue(!Files.exists(
+      output.resolve("OME").resolve(".zattrs")));
   }
 
   /**


### PR DESCRIPTION
Fixes #126.

The root level attributes (if they are written) will now contain a `groups` dictionary that maps each group with multiscales metadata to the corresponding Bio-Formats series index (== Image index in `METADATA.ome.xml`).

As noted in the comments, the paths are dictionary keys and the integer indexes are the values. If the indexes were keys, they would be stored as strings, so this seems easier for a reader. Example tiny plate:

```
$ bin/bioformats2raw "test&plateRows=3&plateCols=2.fake" test-plate
$ head -n 10 test-plate/.zattrs
{
  "groups" : {
    "C/1/0" : 4,
    "C/2/0" : 5,
    "B/1/0" : 2,
    "A/1/0" : 0,
    "B/2/0" : 3,
    "A/2/0" : 1
  },
  "bioformats2raw.layout" : 3,
```

Happy to hear better ideas overall (especially for the attribute name), this is just a place to start.

/cc @kkoz @erindiel @DavidStirling @joshmoore @dgault @sbesson @chris-allan (and feel free to add anyone I missed)