### PR TITLE
Explicitly declare logback as library dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     // implementation 'io.nextflow:nxf-s3fs:1.1.0'
     implementation 'org.lasersonlab:s3fs:2.2.3'
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.4'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.3.4'
 
 
     implementation 'org.openpnp:opencv:3.4.2-1'


### PR DESCRIPTION
Set the version to 1.3.4 which is the latest stable release with JDK 8 support