### PR TITLE
Support for Google Cloud Storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,11 @@ dependencies {
     // implementation 'io.nextflow:nxf-s3fs:1.1.0'
     implementation 'org.lasersonlab:s3fs:2.2.3'
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
+
+    implementation 'com.google.cloud:google-cloud-nio:0.123.10'
+    // implementation 'com.google.cloud:
+
+
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.4'
     implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.3.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,6 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
 
     implementation 'com.google.cloud:google-cloud-nio:0.123.10'
-    // implementation 'com.google.cloud:
-
 
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.4'
     implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.3.4'

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -159,7 +159,7 @@ public class Converter implements Callable<Void> {
       "--output-options=s3fs_path_style_access=true|... " +
       "might be useful for connecting to minio."
   )
-  private Map<String, String> outputOptions;
+  private Map<String, String> outputOptions = new HashMap<String, String>();
 
   @Option(
     names = {"-r", "--resolutions"},


### PR DESCRIPTION
This is a small experiment for writing output directly to GCS.

This is done by including (google-cloud-nio)[https://github.com/googleapis/java-storage-nio]. `outputOptions` needs to be non-null for `newFileSystem()`.

While functional, this is still incomplete:

- [ ] values in `outputOptions` need to be coerced into Integer/Boolean/etc.
- [ ] some mechanism for specifying alternate credentials

As a side note, we tried using Google's S3 interface. It fails on a permissions check in JZarr before writing data.