### PR TITLE
Pyramid TIFF: ignore files where the first/last IFDs have different pixel types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: bioformats2raw
+          name: bioformats2raw ${{ matrix.java }}
           path: build/distributions/*.zip
           retention-days: 30

--- a/src/main/java/com/glencoesoftware/bioformats2raw/PyramidTiffReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/PyramidTiffReader.java
@@ -96,6 +96,12 @@ public class PyramidTiffReader extends BaseTiffReader {
       {
         return false;
       }
+      if (lastIFD.getSamplesPerPixel() != ifd.getSamplesPerPixel()) {
+        return false;
+      }
+      if (lastIFD.getPixelType() != ifd.getPixelType()) {
+        return false;
+      }
 
       int powerOfTwo = 0;
       long width = ifd.getImageWidth();


### PR DESCRIPTION
This is meant to fix an edge case where there are multiple IFDs in descending size order that could be mistaken for a pyramid. The IFDs had a mix of uint8, uint8 RGB, and uint16 data.

Adding the `--extra-readers` option was a work-around in the meantime.