### PR TITLE
Bump Bio-Formats to version 6.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ configurations.all {
 
 dependencies {
     implementation 'net.java.dev.jna:jna:5.10.0'
-    implementation 'ome:formats-gpl:6.11.0'
+    implementation 'ome:formats-gpl:6.11.1'
     implementation 'info.picocli:picocli:4.6.1'
     implementation 'com.univocity:univocity-parsers:2.8.4'
     implementation 'com.bc.zarr:jzarr:0.3.5'


### PR DESCRIPTION
Tracks the latest release of OME Bio-Formats in preparation of the upcoming set of conversion utility releases.