### PR TITLE
Fix dataset paths when `--scale-format-string` is used

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1643,8 +1643,17 @@ public class Converter implements Callable<Void> {
     for (int r = 0; r < resolutions; r++) {
       resolutionString = String.format(
               scaleFormatString, getScaleFormatStringArgs(series, r));
-      String lastPath = resolutionString.substring(
-              resolutionString.lastIndexOf('/') + 1);
+
+      // calculate the relative path to this resolution
+      String lastPath = resolutionString;
+      int lastFileSeparator = lastPath.lastIndexOf('/');
+      if (lastFileSeparator == lastPath.length() - 1) {
+        // if there is a trailing slash, remove it and recalculate
+        // the last file separator index
+        lastPath = lastPath.substring(0, lastFileSeparator);
+        lastFileSeparator = lastPath.lastIndexOf('/');
+      }
+      lastPath = lastPath.substring(lastFileSeparator + 1);
 
       List<Map<String, Object>> transforms =
         new ArrayList<Map<String, Object>>();

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -235,6 +235,14 @@ public class ZarrTest {
     List<Map<String, Object>> multiscales = (List<Map<String, Object>>)
             series0.getAttributes().get("multiscales");
     assertEquals(1, multiscales.size());
+
+    Map<String, Object> multiscale = multiscales.get(0);
+    List<Map<String, Object>> datasets =
+            (List<Map<String, Object>>) multiscale.get("datasets");
+    assertTrue(datasets.size() > 0);
+    for (int i=0; i<datasets.size(); i++) {
+      assertEquals(String.valueOf(i), datasets.get(i).get("path"));
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #179.

This removes trailing slashes (as would be present with `--scale-format-string '%2$d/'`) so that the relative dataset path is not empty.

The associated test should fail without the change to `Converter`, and pass with it. Independent of the test, something like the command in #179 can be used:

```
$ bioformats2raw -p input.fake output.zarr --scale-format-string '%2$d/'
$ bioformats2raw -p input.fake output-minimal.zarr --scale-format-string '%2$d/' --no-root-group --no-ome-meta-export
```

Without this PR, in both cases the `*.zarr/.zattrs` should have empty `path` attributes on each of the `datasets`. With this PR, both commands should result in `path` being populated with something that exists relative to the `.zattrs` location.