### PR TITLE
Add some cautionary statements about adjusting tile sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Alternatively, the `--resolutions` options can be passed to specify the exact nu
 
 
 Maximum tile dimensions can be configured with the `--tile_width` and `--tile_height` options.  Defaults can be viewed with
-`bioformats2raw --help`.
+`bioformats2raw --help`. Be mindful of the downstream workflow when selecting a tile size other than the default.
+A smaller than default tile size is rarely recommended.
 
 If the input file has multiple series, a subset of the series can be converted by specifying a comma-separated list of indexes:
 
@@ -268,7 +269,7 @@ On systems with significant I/O bandwidth, particularly SATA or
 NVMe based storage, you may find sharply diminishing returns with high
 worker counts.  There are significant performance gains to be had utilizing
 larger tile sizes but be mindful of the consequences on the downstream
-workflow.
+workflow. Smaller tile sizes than the default are rarely recommended.
 
 The worker count defaults to the number of detected CPUs.  This may or may not be appropriate for the chosen input data.
 If reading a single tile from the input data requires a lot of memory, decreasing the worker count will be necessary

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -175,13 +175,19 @@ public class Converter implements Callable<Void> {
 
   @Option(
     names = {"-w", "--tile_width"},
-    description = "Maximum tile width to read (default: ${DEFAULT-VALUE})"
+    description = "Maximum tile width (default: ${DEFAULT-VALUE}). " +
+      "This is both the chunk size (in X) when writing Zarr and the tile " +
+      "size used for reading from the original data. Changing the tile " +
+      "size may have performance implications."
   )
   private volatile int tileWidth = 1024;
 
   @Option(
     names = {"-h", "--tile_height"},
-    description = "Maximum tile height to read (default: ${DEFAULT-VALUE})"
+    description = "Maximum tile height (default: ${DEFAULT-VALUE}). " +
+      "This is both the chunk size (in Y) when writing Zarr and the tile " +
+      "size used for reading from the original data. Changing the tile " +
+      "size may have performance implications."
   )
   private volatile int tileHeight = 1024;
 
@@ -447,6 +453,11 @@ public class Converter implements Callable<Void> {
 
     if (fillValue != null && (fillValue < 0 || fillValue > 255)) {
       throw new IllegalArgumentException("Invalid fill value: " + fillValue);
+    }
+    if (tileWidth != 1024 || tileHeight != 1024) {
+      LOGGER.warn("Non-default tile size: {} x {}. " +
+        "This may cause performance issues in some applications.",
+        tileWidth, tileHeight);
     }
 
     OpenCVTools.loadOpenCV();


### PR DESCRIPTION
First try at expanding the tile size documentation, as discussed earlier today. This will also warn if `--tile_width` or `--tile_height` is changed from the default at all.