### PR TITLE
upgrade setup_java action to v3. 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [1.8, 11, 17]
+        java: [8, 11, 17]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -19,18 +19,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
+          cache: "gradle"
       - name: Install libraries
         run: |
           sudo apt-get install -y libblosc1
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
       - name: Run commands
         run: |
           ./gradlew ${{ env.gradle_commands }}


### PR DESCRIPTION
Current version uses deprecated set-output

Check that when ``setup-java`` is run, there is no warning