### PR TITLE
Add a MapAnnotation describing the conversion

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -695,6 +695,12 @@ public class Converter implements Callable<Void> {
           meta.setMapAnnotationNamespace(PROVENANCE_NAMESPACE, annotationIndex);
           meta.setMapAnnotationValue(annotation, annotationIndex);
 
+          if (meta.getCreator() != null) {
+            LOGGER.warn("Overwriting OME-XML Creator attribute: {}",
+              meta.getCreator());
+          }
+          meta.setCreator("bioformats2raw " + getVersion());
+
           String xml = service.getOMEXML(meta);
 
           // write the original OME-XML to a file

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1296,8 +1296,8 @@ public class Converter implements Callable<Integer> {
 
           List<MapPair> annotation = new ArrayList<MapPair>();
           annotation.add(new MapPair("input_path", inputPath.toString()));
-          annotation.add(new MapPair("bioformats2raw", getVersion()));
-          annotation.add(new MapPair("bioformats", FormatTools.VERSION));
+          annotation.add(new MapPair("application", "bioformats2raw"));
+          annotation.add(new MapPair("version", getVersion()));
 
           int annotationIndex = 0;
           try {

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1898,6 +1898,7 @@ public class ZarrTest {
     assertEquals(groupMap.size(), 1);
     assertEquals(groupMap.get(0), "0");
 
+    converter = apiConverter;
     OME ome = getOMEMetadata();
     assertEquals(1, ome.sizeOfImageList());
 

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -36,6 +36,8 @@ import loci.formats.Memoizer;
 import loci.formats.in.FakeReader;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
+import ome.xml.model.MapAnnotation;
+import ome.xml.model.MapPair;
 import ome.xml.model.OME;
 import ome.xml.model.Pixels;
 import picocli.CommandLine;
@@ -1980,6 +1982,15 @@ public class ZarrTest {
     OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
     String omexml = new String(Files.readAllBytes(xml), StandardCharsets.UTF_8);
     assertTrue(xmlService.validateOMEXML(omexml));
-    return (OME) xmlService.createOMEXMLRoot(omexml);
+    OME root = (OME) xmlService.createOMEXMLRoot(omexml);
+    int mapAnnCount = root.getStructuredAnnotations().sizeOfMapAnnotationList();
+    assertTrue(mapAnnCount >= 1);
+    MapAnnotation lastMapAnn =
+      root.getStructuredAnnotations().getMapAnnotation(mapAnnCount - 1);
+    assertEquals(lastMapAnn.getNamespace(), Converter.PROVENANCE_NAMESPACE);
+    List<MapPair> lastMapValue = lastMapAnn.getValue();
+    assertEquals(lastMapValue.size(), 3);
+
+    return root;
   }
 }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1991,6 +1991,8 @@ public class ZarrTest {
     List<MapPair> lastMapValue = lastMapAnn.getValue();
     assertEquals(lastMapValue.size(), 3);
 
+    assertEquals(root.getCreator(), "bioformats2raw " + converter.getVersion());
+
     return root;
   }
 }


### PR DESCRIPTION
Discussed with @erindiel, @emilroz, and @sbesson earlier today that it might be useful to have a record of the input file name and converter version(s). Not expecting this to be merged as-is, but it's a place to continue that discussion.

With this PR, `bioformats2raw test.fake test.zarr` should include the following annotation in `test.zarr/OME/METADATA.ome.xml`:

```
<MapAnnotation ID="Annotation:bioformats2raw:0" Namespace="glencoesoftware.com/ngff/provenance">
  <Value>
    <M K="input_path">test.fake</M>
    <M K="bioformats2raw">0.7.0-SNAPSHOT</M>
    <M K="bioformats">6.11.1</M>
  </Value>
</MapAnnotation>
```

Definitely happy to hear other ideas or better naming suggestions. Maybe the Bio-Formats version doesn't need to be stated explicitly since it can be inferred from the bioformats2raw version?