### PR TITLE
Throw an informative exception if OpenCV is used to downsample int8/int32

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1876,6 +1876,15 @@ public class Converter implements Callable<Integer> {
       readers.put(workingReader);
     }
 
+    if ((pixelType == FormatTools.INT8 || pixelType == FormatTools.INT32) &&
+      getDownsampling() != Downsampling.SIMPLE && resolutions > 0)
+    {
+      String type = FormatTools.getPixelTypeString(pixelType);
+      throw new UnsupportedOperationException(
+        "OpenCV does not support downsampling " + type + " data. " +
+        "See https://github.com/opencv/opencv/issues/7862");
+    }
+
     LOGGER.info(
       "Preparing to write pyramid sizeX {} (tileWidth: {}) " +
       "sizeY {} (tileWidth: {}) sizeZ {} (tileDepth: {}) imageCount {}",

--- a/src/main/java/com/glencoesoftware/bioformats2raw/OpenCVTools.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/OpenCVTools.java
@@ -97,13 +97,6 @@ public class OpenCVTools {
     byte[] tile, int pixelType, int width, int height, int scale,
     Downsampling downsampling)
   {
-    if (pixelType == FormatTools.INT8 || pixelType == FormatTools.INT32) {
-      String type = FormatTools.getPixelTypeString(pixelType);
-      throw new UnsupportedOperationException(
-        "OpenCV does not support downsampling " + type + " data. " +
-        "See https://github.com/opencv/opencv/issues/7862");
-    }
-
     boolean floatingPoint = FormatTools.isFloatingPoint(pixelType);
     int bytesPerPixel = FormatTools.getBytesPerPixel(pixelType);
     Object pixels =

--- a/src/main/java/com/glencoesoftware/bioformats2raw/OpenCVTools.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/OpenCVTools.java
@@ -97,6 +97,13 @@ public class OpenCVTools {
     byte[] tile, int pixelType, int width, int height, int scale,
     Downsampling downsampling)
   {
+    if (pixelType == FormatTools.INT8 || pixelType == FormatTools.INT32) {
+      String type = FormatTools.getPixelTypeString(pixelType);
+      throw new UnsupportedOperationException(
+        "OpenCV does not support downsampling " + type + " data. " +
+        "See https://github.com/opencv/opencv/issues/7862");
+    }
+
     boolean floatingPoint = FormatTools.isFloatingPoint(pixelType);
     int bytesPerPixel = FormatTools.getBytesPerPixel(pixelType);
     Object pixels =

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -946,6 +946,38 @@ public class ZarrTest {
   }
 
   /**
+   * Make sure an informative exception is thrown when trying to use
+   * OpenCV to downsample int8 data.
+   * See https://github.com/opencv/opencv/issues/7862
+   */
+  @Test
+  public void testUnsupportedOpenCVType() throws Exception {
+    input = fake("pixelType", "int8");
+    assertThrows(ExecutionException.class, () -> {
+      assertTool("--downsample-type", "LINEAR");
+    });
+  }
+
+  /**
+   * Make sure an informative exception is thrown when trying to use
+   * OpenCV to downsample int32 data. Uses the API instead of
+   * command line arguments.
+   * See https://github.com/opencv/opencv/issues/7862
+   */
+  @Test
+  public void testUnsupportedOpenCVTypeAPI() throws Exception {
+    input = fake("pixelType", "int32");
+    Converter apiConverter = new Converter();
+    apiConverter.setInputPath(input.toString());
+    apiConverter.setOutputPath(output.toString());
+    apiConverter.setDownsampling(Downsampling.AREA);
+
+    assertThrows(UnsupportedOperationException.class, () -> {
+      apiConverter.call();
+    });
+  }
+
+  /**
    * Test that nested storage works equivalently.
    *
    * @param nested whether to use "/" or "." as the chunk separator.


### PR DESCRIPTION
See #198. The test cases in https://github.com/glencoesoftware/bioformats2raw/issues/198#issuecomment-1494513544 should now throw a more meaningful exception that references the OpenCV issue.

An OpenCV downsampling type with an int8/int32 image that is too small for pyramid generation should still convert without an exception.

cc @blowekamp