### PR TITLE
Set wildcard classpath on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ startScripts {
   classpath += files('src/dist/lib/config/')
 
   doLast {
-    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%\\\\lib\\\\*')
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,10 @@ startScripts {
   // likely due to https://issues.gradle.org/browse/GRADLE-2991
   // see also discussion in https://github.com/glencoesoftware/bioformats2raw/pull/169
   classpath += files('src/dist/lib/config/')
+
+  doLast {
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
+  }
 }
 
 publishing {


### PR DESCRIPTION
Fixes #14.

This worked for me on Windows. Without this PR, built and unzipped `bioformats2raw-0.7.0-SNAPSHOT.zip`, then:

```
> mv bioformats2raw-0.7.0-SNAPSHOT C:\Users\melissa\data\long-path-name-test\
> cd C:\Users\melissa\data\long-path-name-test\bioformats2raw-0.7.0-SNAPSHOT
> .\bin\bioformats2raw.bat test.fake test.zarr --compression null
The input line is too long.
The syntax of the command is incorrect.
```

With this PR, the same test should successfully create `test.zarr`.

If we're happy with this approach, raw2ometiff can get the same fix.

/cc @jburel
