### PR TITLE
Add reset methods for each option

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -799,6 +799,249 @@ public class Converter implements Callable<Integer> {
     dimensionOrder = order;
   }
 
+  // Option resetters - reset to defaults
+
+  /**
+   * Reset all options to their default values.
+   */
+  public void resetOptions() {
+    resetInputPath();
+    resetOutputPath();
+    resetOutputOptions();
+    resetResolutions();
+    resetSeriesList();
+    resetTileWidth();
+    resetTileHeight();
+    resetChunkDepth();
+    resetLogLevel();
+    resetProgressBars();
+    resetPrintVersionOnly();
+    resetMaxWorkers();
+    resetMaxCachedTiles();
+    resetCompression();
+    resetCompressionProperties();
+    resetExtraReaders();
+    resetCalculateOMEROMetadata();
+    resetNested();
+    resetPyramidName();
+    resetScaleFormat();
+    resetAdditionalScaleFormatCSV();
+    resetMemoDirectory();
+    resetKeepMemoFiles();
+    resetDownsampling();
+    resetOverwrite();
+    resetFillValue();
+    resetReaderOptions();
+    resetNoHCS();
+    resetNoOMEMeta();
+    resetNoRootGroup();
+    resetReuseExistingResolutions();
+    resetMinImageSize();
+    resetDimensionOrder();
+  }
+
+  /**
+   */
+  public void resetInputPath() {
+    inputPath = null;
+  }
+
+  /**
+   */
+  public void resetOutputPath() {
+    outputLocation = null;
+  }
+
+  /**
+   */
+  public void resetOutputOptions() {
+    outputOptions = null;
+  }
+
+  /**
+   */
+  public void resetResolutions() {
+    pyramidResolutions = null;
+  }
+
+  /**
+   */
+  public void resetSeriesList() {
+    seriesList.clear();
+  }
+
+  /**
+   */
+  public void resetTileWidth() {
+    tileWidth = 1024;
+  }
+
+  /**
+   */
+  public void resetTileHeight() {
+    tileHeight = 1024;
+  }
+
+  /**
+   */
+  public void resetChunkDepth() {
+    chunkDepth = 1;
+  }
+
+  /**
+   */
+  public void resetLogLevel() {
+    logLevel = "WARN";
+  }
+
+  /**
+   */
+  public void resetProgressBars() {
+    progressBars = false;
+  }
+
+  /**
+   */
+  public void resetPrintVersionOnly() {
+    printVersion = false;
+  }
+
+  /**
+   */
+  public void resetMaxWorkers() {
+    maxWorkers = (int) Math.min(4, Runtime.getRuntime().availableProcessors());
+  }
+
+  /**
+   */
+  public void resetMaxCachedTiles() {
+    maxCachedTiles = 64;
+  }
+
+  /**
+   */
+  public void resetCompression() {
+    compressionType = ZarrCompression.blosc;
+  }
+
+  /**
+   */
+  public void resetCompressionProperties() {
+    compressionProperties.clear();
+  }
+
+  /**
+   */
+  public void resetExtraReaders() {
+    extraReaders = new Class[] {
+      PyramidTiffReader.class, MiraxReader.class,
+      BioTekReader.class, ND2PlateReader.class
+    };
+  }
+
+  /**
+   */
+  public void resetCalculateOMEROMetadata() {
+    omeroMetadata = true;
+  }
+
+  /**
+   */
+  public void resetNested() {
+    nested = true;
+  }
+
+  /**
+   */
+  public void resetPyramidName() {
+    pyramidName = null;
+  }
+
+  /**
+   */
+  public void resetScaleFormat() {
+    scaleFormatString = "%d/%d";
+  }
+
+  /**
+   */
+  public void resetAdditionalScaleFormatCSV() {
+    additionalScaleFormatStringArgsCsv = null;
+    additionalScaleFormatStringArgs = null;
+  }
+
+  /**
+   */
+  public void resetMemoDirectory() {
+    memoDirectory = null;
+  }
+
+  /**
+   */
+  public void resetKeepMemoFiles() {
+    keepMemoFiles = false;
+  }
+
+  /**
+   */
+  public void resetDownsampling() {
+    downsampling = Downsampling.SIMPLE;
+  }
+
+  /**
+   */
+  public void resetOverwrite() {
+    overwrite = false;
+  }
+
+  /**
+   */
+  public void resetFillValue() {
+    fillValue = null;
+  }
+
+  /**
+   */
+  public void resetReaderOptions() {
+    readerOptions.clear();
+  }
+
+  /**
+   */
+  public void resetNoHCS() {
+    noHCS = false;
+  }
+
+  /**
+   */
+  public void resetNoOMEMeta() {
+    noOMEMeta = false;
+  }
+
+  /**
+   */
+  public void resetNoRootGroup() {
+    noRootGroup = false;
+  }
+
+  /**
+   */
+  public void resetReuseExistingResolutions() {
+    reuseExistingResolutions = false;
+  }
+
+  /**
+   */
+  public void resetMinImageSize() {
+    minSize = MIN_SIZE;
+  }
+
+  /**
+   */
+  public void resetDimensionOrder() {
+    dimensionOrder = DimensionOrder.XYZCT;
+  }
+
   // Option getters
 
   /**

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -867,7 +867,7 @@ public class Converter implements Callable<Integer> {
   /**
    */
   public void resetSeriesList() {
-    seriesList.clear();
+    seriesList = new ArrayList<Integer>();
   }
 
   /**
@@ -927,7 +927,7 @@ public class Converter implements Callable<Integer> {
   /**
    */
   public void resetCompressionProperties() {
-    compressionProperties.clear();
+    compressionProperties = new HashMap<String, Object>();
   }
 
   /**
@@ -1003,7 +1003,7 @@ public class Converter implements Callable<Integer> {
   /**
    */
   public void resetReaderOptions() {
-    readerOptions.clear();
+    readerOptions = new ArrayList<String>();
   }
 
   /**
@@ -1048,7 +1048,7 @@ public class Converter implements Callable<Integer> {
    * @return path to input data
    */
   public String getInputPath() {
-    return inputPath.toString();
+    return inputPath == null ? null : inputPath.toString();
   }
 
   /**

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1984,6 +1984,40 @@ public class ZarrTest {
   }
 
   /**
+   * Check that setting and resetting options via API will reset options to
+   * their default values.
+   */
+  @Test
+  public void testResetOptions() throws Exception {
+    input = fake("series", "2", "sizeX", "4096", "sizeY", "4096");
+
+    Converter apiConverter = new Converter();
+    apiConverter.setInputPath(input.toString());
+    apiConverter.setOutputPath(output.toString());
+    apiConverter.setSeriesList(Collections.singletonList(1));
+    apiConverter.setTileWidth(128);
+    apiConverter.setTileHeight(128);
+
+    assertEquals(apiConverter.getInputPath(), input.toString());
+    assertEquals(apiConverter.getOutputPath(), output.toString());
+    assertEquals(apiConverter.getSeriesList(), Collections.singletonList(1));
+    assertEquals(apiConverter.getTileWidth(), 128);
+    assertEquals(apiConverter.getTileHeight(), 128);
+
+    apiConverter.resetInputPath();
+    assertEquals(apiConverter.getInputPath(), null);
+
+    apiConverter.setInputPath(input.toString());
+
+    apiConverter.resetOptions();
+    assertEquals(apiConverter.getInputPath(), null);
+    assertEquals(apiConverter.getOutputPath(), null);
+    assertEquals(apiConverter.getSeriesList().size(), 0);
+    assertEquals(apiConverter.getTileWidth(), 1024);
+    assertEquals(apiConverter.getTileHeight(), 1024);
+  }
+
+  /**
    * @param root dataset root path
    * @param rowCount total rows the plate could contain
    * @param colCount total columns the plate could contain


### PR DESCRIPTION
As discussed with @DavidStirling, there wasn't a way to reset options to their default value, and some of the setters contain validation logic that prevents the default value from being accepted (e.g. `pyramidResolutions`).

This PR adds a `reset` method corresponding to the `get` and `set` method for each option. `resetOptions()` calls each individual option's resetter for convenience. Open to other thoughts on how to implement this, what's in 5a99e2b was just the most straightforward change.

Once we're happy with changes here, raw2ometiff will need the same treatment. This may end up being what drives the 0.8.0 release.