### PR TITLE
Add variants of all options with underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Alternatively, the `--resolutions` options can be passed to specify the exact nu
     bioformats2raw /path/to/file.svs /path/to/zarr-pyramid --resolutions 6
 
 
-Maximum tile dimensions can be configured with the `--tile_width` and `--tile_height` options.  Defaults can be viewed with
+Maximum tile dimensions can be configured with the `--tile-width` and `--tile-height` options.  Defaults can be viewed with
 `bioformats2raw --help`. Be mindful of the downstream workflow when selecting a tile size other than the default.
 A smaller than default tile size is rarely recommended.
 
@@ -276,9 +276,9 @@ Performance
 This package is __highly__ sensitive to underlying hardware as well as
 the following configuration options:
 
- * `--max_workers`
- * `--tile_width`
- * `--tile_height`
+ * `--max-workers`
+ * `--tile-width`
+ * `--tile-height`
 
 On systems with significant I/O bandwidth, particularly SATA or
 NVMe based storage, you may find sharply diminishing returns with high

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -307,7 +307,7 @@ public class Converter implements Callable<Integer> {
    * @param width tile width
    */
   @Option(
-    names = {"-w", "--tile_width"},
+    names = {"-w", "--tile-width", "--tile_width"},
     description = "Maximum tile width (default: ${DEFAULT-VALUE}). " +
       "This is both the chunk size (in X) when writing Zarr and the tile " +
       "size used for reading from the original data. Changing the tile " +
@@ -329,7 +329,7 @@ public class Converter implements Callable<Integer> {
    * @param height tile height
    */
   @Option(
-    names = {"-h", "--tile_height"},
+    names = {"-h", "--tile-height", "--tile_height"},
     description = "Maximum tile height (default: ${DEFAULT-VALUE}). " +
       "This is both the chunk size (in Y) when writing Zarr and the tile " +
       "size used for reading from the original data. Changing the tile " +
@@ -351,7 +351,7 @@ public class Converter implements Callable<Integer> {
    * @param depth Z chunk size
    */
   @Option(
-    names = {"-z", "--chunk_depth"},
+    names = {"-z", "--chunk-depth", "--chunk_depth"},
     description = "Maximum chunk depth to read (default: ${DEFAULT-VALUE}) ",
     defaultValue = "1"
   )
@@ -421,7 +421,7 @@ public class Converter implements Callable<Integer> {
    * @param workers maximum worker count
    */
   @Option(
-    names = "--max_workers",
+    names = {"--max-workers", "--max_workers"},
     description = "Maximum number of workers (default: ${DEFAULT-VALUE})"
   )
   public void setMaxWorkers(int workers) {
@@ -441,7 +441,7 @@ public class Converter implements Callable<Integer> {
    * @param maxTiles maximum number of cached tiles
    */
   @Option(
-    names = "--max_cached_tiles",
+    names = {"--max-cached-tiles", "--max_cached_tiles"},
     description =
       "Maximum number of tiles that will be cached across all "
       + "workers (default: ${DEFAULT-VALUE})",


### PR DESCRIPTION
This is a minor proposal which aims to improve the consistency of the various options of the converter. All converter options using underscore separators are updated to also support the variant using dash separators i.e. following the GNU conventions for long arguments
