### PR TITLE
Update progress listener API to provide tile counts at each start notification

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1347,7 +1347,7 @@ public class Converter implements Callable<Integer> {
           totalTiles += count;
         }
       }
-      getProgressListener().notifyTotalTileCount(totalTiles);
+      getProgressListener().notifyTotalCounts(seriesList.size(), totalTiles);
 
       for (Integer index : seriesList) {
         try {

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1347,7 +1347,7 @@ public class Converter implements Callable<Integer> {
           totalTiles += count;
         }
       }
-      getProgressListener().notifyTotalCounts(seriesList.size(), totalTiles);
+      getProgressListener().notifyStart(seriesList.size(), totalTiles);
 
       for (Integer index : seriesList) {
         try {

--- a/src/main/java/com/glencoesoftware/bioformats2raw/IProgressListener.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/IProgressListener.java
@@ -12,11 +12,21 @@ import java.util.EventListener;
 public interface IProgressListener extends EventListener {
 
   /**
+   * Indicates the total number of tiles in this conversion operation.
+   * Includes all resolutions in all series.
+   *
+   * @param tileCount total number of tiles
+   */
+  void notifyTotalTileCount(long tileCount);
+
+  /**
    * Indicates the beginning of processing a particular series.
    *
    * @param series the series index being processed
+   * @param resolutionCount total number of resolutions in this series
+   * @param tileCount total number of tiles for all resolutions in this series
    */
-  void notifySeriesStart(int series);
+  void notifySeriesStart(int series, int resolutionCount, int tileCount);
 
   /**
    * Indicates the end of processing a particular series.

--- a/src/main/java/com/glencoesoftware/bioformats2raw/IProgressListener.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/IProgressListener.java
@@ -12,21 +12,22 @@ import java.util.EventListener;
 public interface IProgressListener extends EventListener {
 
   /**
-   * Indicates the total number of tiles in this conversion operation.
+   * Indicates the total number of chunks in this conversion operation.
    * Includes all resolutions in all series.
    *
-   * @param tileCount total number of tiles
+   * @param seriesCount total number of series
+   * @param chunkCount total number of chunks
    */
-  void notifyTotalTileCount(long tileCount);
+  void notifyTotalCounts(int seriesCount, long chunkCount);
 
   /**
    * Indicates the beginning of processing a particular series.
    *
    * @param series the series index being processed
    * @param resolutionCount total number of resolutions in this series
-   * @param tileCount total number of tiles for all resolutions in this series
+   * @param chunkCount total number of chunks for all resolutions in this series
    */
-  void notifySeriesStart(int series, int resolutionCount, int tileCount);
+  void notifySeriesStart(int series, int resolutionCount, int chunkCount);
 
   /**
    * Indicates the end of processing a particular series.
@@ -39,9 +40,9 @@ public interface IProgressListener extends EventListener {
    * Indicates the beginning of processing a particular resolution.
    *
    * @param resolution the resolution index being processed
-   * @param tileCount the total number of tiles in this resolution
+   * @param chunkCount the total number of chunks in this resolution
    */
-  void notifyResolutionStart(int resolution, int tileCount);
+  void notifyResolutionStart(int resolution, int chunkCount);
 
   /**
    * Indicates the end of processing a particular resolution.

--- a/src/main/java/com/glencoesoftware/bioformats2raw/IProgressListener.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/IProgressListener.java
@@ -18,7 +18,7 @@ public interface IProgressListener extends EventListener {
    * @param seriesCount total number of series
    * @param chunkCount total number of chunks
    */
-  void notifyTotalCounts(int seriesCount, long chunkCount);
+  void notifyStart(int seriesCount, long chunkCount);
 
   /**
    * Indicates the beginning of processing a particular series.

--- a/src/main/java/com/glencoesoftware/bioformats2raw/NoOpProgressListener.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/NoOpProgressListener.java
@@ -10,7 +10,7 @@ package com.glencoesoftware.bioformats2raw;
 public class NoOpProgressListener implements IProgressListener {
 
   @Override
-  public void notifyTotalCounts(int seriesCount, long chunkCount) {
+  public void notifyStart(int seriesCount, long chunkCount) {
   }
 
   @Override

--- a/src/main/java/com/glencoesoftware/bioformats2raw/NoOpProgressListener.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/NoOpProgressListener.java
@@ -10,7 +10,13 @@ package com.glencoesoftware.bioformats2raw;
 public class NoOpProgressListener implements IProgressListener {
 
   @Override
-  public void notifySeriesStart(int series) {
+  public void notifyTotalTileCount(long tileCount) {
+  }
+
+  @Override
+  public void notifySeriesStart(int series, int resolutionCount,
+    int tileCount)
+  {
   }
 
   @Override

--- a/src/main/java/com/glencoesoftware/bioformats2raw/NoOpProgressListener.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/NoOpProgressListener.java
@@ -10,12 +10,12 @@ package com.glencoesoftware.bioformats2raw;
 public class NoOpProgressListener implements IProgressListener {
 
   @Override
-  public void notifyTotalTileCount(long tileCount) {
+  public void notifyTotalCounts(int seriesCount, long chunkCount) {
   }
 
   @Override
   public void notifySeriesStart(int series, int resolutionCount,
-    int tileCount)
+    int chunkCount)
   {
   }
 
@@ -24,7 +24,7 @@ public class NoOpProgressListener implements IProgressListener {
   }
 
   @Override
-  public void notifyResolutionStart(int resolution, int tileCount) {
+  public void notifyResolutionStart(int resolution, int chunkCount) {
   }
 
   @Override

--- a/src/main/java/com/glencoesoftware/bioformats2raw/ProgressBarListener.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/ProgressBarListener.java
@@ -33,7 +33,7 @@ public class ProgressBarListener implements IProgressListener {
   }
 
   @Override
-  public void notifyTotalCounts(int seriesCount, long chunkCount) {
+  public void notifyStart(int seriesCount, long chunkCount) {
     // intentional no-op
   }
 

--- a/src/main/java/com/glencoesoftware/bioformats2raw/ProgressBarListener.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/ProgressBarListener.java
@@ -33,13 +33,13 @@ public class ProgressBarListener implements IProgressListener {
   }
 
   @Override
-  public void notifyTotalTileCount(long tileCount) {
+  public void notifyTotalCounts(int seriesCount, long chunkCount) {
     // intentional no-op
   }
 
   @Override
   public void notifySeriesStart(int series, int resolutionCount,
-    int tileCount)
+    int chunkCount)
   {
     currentSeries = series;
   }
@@ -50,9 +50,9 @@ public class ProgressBarListener implements IProgressListener {
   }
 
   @Override
-  public void notifyResolutionStart(int resolution, int tileCount) {
+  public void notifyResolutionStart(int resolution, int chunkCount) {
     ProgressBarBuilder builder = new ProgressBarBuilder()
-      .setInitialMax(tileCount)
+      .setInitialMax(chunkCount)
       .setTaskName(String.format("[%d/%d]", currentSeries, resolution));
 
     if (!(logLevel.equals("OFF") ||

--- a/src/main/java/com/glencoesoftware/bioformats2raw/ProgressBarListener.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/ProgressBarListener.java
@@ -32,14 +32,21 @@ public class ProgressBarListener implements IProgressListener {
     logLevel = level;
   }
 
+  @Override
+  public void notifyTotalTileCount(long tileCount) {
+    // intentional no-op
+  }
 
   @Override
-  public void notifySeriesStart(int series) {
+  public void notifySeriesStart(int series, int resolutionCount,
+    int tileCount)
+  {
     currentSeries = series;
   }
 
   @Override
   public void notifySeriesEnd(int series) {
+    // intentional no-op
   }
 
   @Override

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/TestProgressListener.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/TestProgressListener.java
@@ -22,7 +22,7 @@ public class TestProgressListener implements IProgressListener {
   private long totalTiles = 0;
 
   @Override
-  public void notifyTotalCounts(int seriesCount, long tileCount) {
+  public void notifyStart(int seriesCount, long tileCount) {
     totalTiles = tileCount;
   }
 

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/TestProgressListener.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/TestProgressListener.java
@@ -18,9 +18,17 @@ public class TestProgressListener implements IProgressListener {
   private int startedTiles = 0;
   private int completedTiles = 0;
   private int expectedTileCount = 0;
+  private int seriesTiles = 0;
+  private long totalTiles = 0;
 
   @Override
-  public void notifySeriesStart(int series) {
+  public void notifyTotalTileCount(long tileCount) {
+    totalTiles = tileCount;
+  }
+
+  @Override
+  public void notifySeriesStart(int series, int res, int tiles) {
+    seriesTiles = tiles;
   }
 
   @Override
@@ -62,6 +70,20 @@ public class TestProgressListener implements IProgressListener {
    */
   public Integer[] getTileCounts() {
     return finishedResolutions.toArray(new Integer[finishedResolutions.size()]);
+  }
+
+  /**
+   * @return the reported number of tiles for the most recent series
+   */
+  public int getSeriesTileCount() {
+    return seriesTiles;
+  }
+
+  /**
+   * @return the reported number of total tiles for the conversion
+   */
+  public long getTotalTileCount() {
+    return totalTiles;
   }
 
 }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/TestProgressListener.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/TestProgressListener.java
@@ -22,7 +22,7 @@ public class TestProgressListener implements IProgressListener {
   private long totalTiles = 0;
 
   @Override
-  public void notifyTotalTileCount(long tileCount) {
+  public void notifyTotalCounts(int seriesCount, long tileCount) {
     totalTiles = tileCount;
   }
 
@@ -68,21 +68,21 @@ public class TestProgressListener implements IProgressListener {
    *
    * @return an array with one element per resolution
    */
-  public Integer[] getTileCounts() {
+  public Integer[] getChunkCounts() {
     return finishedResolutions.toArray(new Integer[finishedResolutions.size()]);
   }
 
   /**
    * @return the reported number of tiles for the most recent series
    */
-  public int getSeriesTileCount() {
+  public int getSeriesChunkCount() {
     return seriesTiles;
   }
 
   /**
    * @return the reported number of total tiles for the conversion
    */
-  public long getTotalTileCount() {
+  public long getTotalChunkCount() {
     return totalTiles;
   }
 

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -708,15 +708,15 @@ public class ZarrTest {
       throw new RuntimeException(t);
     }
 
-    Integer[] expectedTileCounts = new Integer[] {320, 80, 20, 5, 5, 5};
-    Integer[] tileCounts = listener.getTileCounts();
-    assertArrayEquals(expectedTileCounts, tileCounts);
-    long totalTileCount = 0;
-    for (Integer t : expectedTileCounts) {
-      totalTileCount += t;
+    Integer[] expectedChunkCounts = new Integer[] {320, 80, 20, 5, 5, 5};
+    Integer[] chunkCounts = listener.getChunkCounts();
+    assertArrayEquals(expectedChunkCounts, chunkCounts);
+    long totalChunkCount = 0;
+    for (Integer t : expectedChunkCounts) {
+      totalChunkCount += t;
     }
-    assertEquals(totalTileCount, listener.getTotalTileCount());
-    assertEquals(totalTileCount, listener.getSeriesTileCount());
+    assertEquals(totalChunkCount, listener.getTotalChunkCount());
+    assertEquals(totalChunkCount, listener.getSeriesChunkCount());
   }
 
   private int bytesPerPixel(DataType dataType) {

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -711,6 +711,12 @@ public class ZarrTest {
     Integer[] expectedTileCounts = new Integer[] {320, 80, 20, 5, 5, 5};
     Integer[] tileCounts = listener.getTileCounts();
     assertArrayEquals(expectedTileCounts, tileCounts);
+    long totalTileCount = 0;
+    for (Integer t : expectedTileCounts) {
+      totalTileCount += t;
+    }
+    assertEquals(totalTileCount, listener.getTotalTileCount());
+    assertEquals(totalTileCount, listener.getSeriesTileCount());
   }
 
   private int bytesPerPixel(DataType dataType) {


### PR DESCRIPTION
This should make it easier for a listener implementation to use a single progress bar for the whole conversion, instead of one progress bar per resolution (as discussed with @DavidStirling).

Updating the notifications in Converter requires pre-calculating tile and resolution counts before starting to write tiles, but that also means failing faster if the pixel type and downsampling (or other options) are incompatible.

raw2ometiff will need similar updates once we're happy with this, as it consumes the progress listener API and implementations here. Might be a case for a 0.8.0-rc1 that includes this, so we can more easily test with all of the downstream applications.