### PR TITLE
Add GPL license metadata to published POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,14 @@ publishing {
     publications {
         bioformats2raw(MavenPublication) {
             from components.java
+            pom {
+                licenses {
+                    license {
+                        name = 'GNU General Public License version 2'
+                        url = 'http://www.gnu.org/licenses/gpl-2.0.txt'
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Following a discussion yesterday with @DavidStirling and @melissalinkert about generating a public report of the NGFF dependencies and their licenses, this should add the licensing metadata to the POM for this component and simplify the downstream aggregation and reporting.

This can be tested by running `./gradlew publishToMavenLocal`. Without this PR, the POM file stored under `~/.m2/repository` should have no `license` markup. With this PR included, it should include a single license referencing the GNU GPL v2 as per the top-level license of the repository