### PR TITLE
Move logging configuration to beginning of call() method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,8 @@ distributions {
 }
 
 startScripts {
+  defaultJvmOpts = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED']
+
   // placing logback.xml somewhere under src/dist/lib/ keeps it out of
   // bioformats2raw-*.jar but automatically includes it in the distribution zip
   // the directory containing logback.xml must be explicitly added to the

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1090,6 +1090,10 @@ public class Converter implements Callable<Integer> {
    */
   @Override
   public Integer call() throws Exception {
+    ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger)
+        LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    root.setLevel(Level.toLevel(logLevel));
+
     if (printVersion) {
       String version = Optional.ofNullable(
         this.getClass().getPackage().getImplementationVersion()
@@ -1117,10 +1121,6 @@ public class Converter implements Callable<Integer> {
     }
 
     OpenCVTools.loadOpenCV();
-
-    ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger)
-        LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-    root.setLevel(Level.toLevel(logLevel));
 
     if (progressBars) {
       setProgressListener(new ProgressBarListener(logLevel));


### PR DESCRIPTION
This ensures that the correct log level is set before OpenCV is loaded.

Compare using `--log-level ERROR` with and without this PR.