### PR TITLE
Fix progress and help options

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -401,7 +401,6 @@ public class Converter implements Callable<Integer> {
   @Option(
     names = {"-p", "--progress"},
     description = "Print progress bars during conversion",
-    help = true,
     defaultValue = "false"
   )
   public void setProgressBars(boolean useProgressBars) {

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -138,6 +138,7 @@ public class Converter implements Callable<Integer> {
   private volatile String logLevel;
   private volatile boolean progressBars = false;
   private volatile boolean printVersion = false;
+  private volatile boolean help = false;
 
   private volatile int maxWorkers;
   private volatile int maxCachedTiles;
@@ -421,6 +422,21 @@ public class Converter implements Callable<Integer> {
   )
   public void setPrintVersionOnly(boolean versionOnly) {
     printVersion = versionOnly;
+  }
+
+  /**
+   * Configure whether to print help and exit without converting.
+   *
+   * @param helpOnly whether or not to print help and exit
+   */
+  @Option(
+    names = "--help",
+    description = "Print usage information and exit",
+    usageHelp = true,
+    defaultValue = "false"
+  )
+  public void setHelp(boolean helpOnly) {
+    help = helpOnly;
   }
 
   /**
@@ -918,6 +934,13 @@ public class Converter implements Callable<Integer> {
   }
 
   /**
+   * @return true if only usage info is displayed
+   */
+  public boolean getHelp() {
+    return help;
+  }
+
+  /**
    * @return maximum number of worker threads
    */
   public int getMaxWorkers() {
@@ -1093,6 +1116,10 @@ public class Converter implements Callable<Integer> {
     ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger)
         LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     root.setLevel(Level.toLevel(logLevel));
+
+    if (help) {
+      return -1;
+    }
 
     if (printVersion) {
       String version = Optional.ofNullable(


### PR DESCRIPTION
As discussed earlier today with @sbesson and @chris-allan.

With this change, commands similar to:

```
$ bioformats2raw --help
$ bioformats2raw -p --foo test.fake test.zarr
$ bioformats2raw -p --help
```

should print a usage message and exit.

I don't know why the `help` flag was set for `-p`/`--progress-bars`, maybe @joshmoore remembers from the initial implementation in #83?

raw2ometiff will need a similar update once we're happy with the state of this PR.