### PR TITLE
Add "--no-original-metadata" option to omit original metadata from METADATA.ome.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ which can then be used to create a hierarchy by date, username, and ID:
 Prevents the input file's OME-XML metadata from being saved.  There will no longer be an `OME` directory
 under the top-level output directory.
 
+#### --no-original-metadata
+
+Prevents `OriginalMetadata` annotations from being written to `OME/METADATA.ome.xml`.
+This can reduce the size of the OME-XML, and as discussed in [#250](https://github.com/glencoesoftware/bioformats2raw/issues/250),
+is one way to guard against unwanted experimental metadata being included in the conversion.
+
 #### --no-root-group
 
 By default, a Zarr group (`.zgroup` file) is written in the top-level output directory.

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -139,6 +139,7 @@ public class Converter implements Callable<Integer> {
   private volatile boolean progressBars = false;
   private volatile boolean printVersion = false;
   private volatile boolean help = false;
+  private volatile boolean originalMetadata = true;
 
   private volatile int maxWorkers;
   private volatile int maxCachedTiles;
@@ -778,6 +779,22 @@ public class Converter implements Callable<Integer> {
   }
 
   /**
+   * Set whether or not to write original metadata key/value pairs in
+   * OME-XML metadata.
+   * By default, original metadata is written.
+   *
+   * @param noOriginalMetadata true if original metadata should not be written
+   */
+  @Option(
+          names = "--no-original-metadata",
+          description = "Turn off original metadata exporting",
+          defaultValue = "false"
+  )
+  public void setNoOriginalMetadata(boolean noOriginalMetadata) {
+    originalMetadata = !noOriginalMetadata;
+  }
+
+  /**
    * Set whether or not to write a root Zarr group.
    * By default, the root group is written.
    *
@@ -1077,6 +1094,13 @@ public class Converter implements Callable<Integer> {
   }
 
   /**
+   * @return true if original metadata will be written in the OME-XML
+   */
+  public boolean getOriginalMetadata() {
+    return originalMetadata;
+  }
+
+  /**
    * @return true if a root Zarr group will not be written
    */
   public boolean getNoRootGroup() {
@@ -1261,7 +1285,7 @@ public class Converter implements Callable<Integer> {
         memoizer.setMetadataOptions(options);
       }
 
-      memoizer.setOriginalMetadataPopulated(!noOMEMeta);
+      memoizer.setOriginalMetadataPopulated(!noOMEMeta && originalMetadata);
       memoizer.setFlattenedResolutions(false);
       memoizer.setMetadataFiltered(true);
       memoizer.setMetadataStore(createMetadata());

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1659,6 +1659,32 @@ public class ZarrTest {
   }
 
   /**
+   * Convert with the "--no-original-metadata" option.
+   * Conversion should succeed and OME-XML should be written,
+   * but there should be no original metadata annotations despite
+   * original metadata being present in the input data.
+   */
+  @Test
+  public void testNoOriginalMetadata() throws Exception {
+    Map<String, String> originalMetadata = new HashMap<String, String>();
+    originalMetadata.put("key1", "value1");
+    originalMetadata.put("key2", "value2");
+
+    input = fake(null, null, originalMetadata);
+    assertTool("--no-original-metadata");
+    Path omexml = output.resolve("OME").resolve("METADATA.ome.xml");
+    StringBuilder xml = new StringBuilder();
+    Files.lines(omexml).forEach(v -> xml.append(v));
+
+    OMEXMLService service =
+      new ServiceFactory().getInstance(OMEXMLService.class);
+    OMEXMLMetadata retrieve =
+      (OMEXMLMetadata) service.createOMEXMLMetadata(xml.toString());
+    Hashtable convertedMetadata = service.getOriginalMetadata(retrieve);
+    assertEquals(convertedMetadata, null);
+  }
+
+  /**
    * Convert with the --use-existing-resolutions option.  Conversion should
    * produce multiscales matching the input resolution numbers and scale.
    */


### PR DESCRIPTION
Fixes #250.

As the test demonstrates, converting input data that has original metadata with the new `--no-original-metadata` option should result in a `METADATA.ome.xml` that does not contain `OriginalMetadata` annotations. Default behavior should be unchanged.