### PR TITLE
Fix `--fill-value` to use setFillColor(...) API

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/BioTekReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/BioTekReader.java
@@ -176,7 +176,7 @@ public class BioTekReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    Arrays.fill(buf, (byte) 0);
+    Arrays.fill(buf, getFillColor());
 
     BioTekWell well = wells.get(getWellIndex(getSeries()));
     String file = well.getFile(getFieldIndex(getSeries()), getZCTCoords(no));

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -708,8 +708,7 @@ public class Converter implements Callable<Integer> {
    */
   @Option(
           names = "--fill-value",
-          description = "Default value to fill in for missing tiles (0-255)" +
-                        " (currently .mrxs only)",
+          description = "Default value to fill in for missing tiles (0-255)",
           defaultValue = Option.NULL_VALUE
   )
   public void setFillValue(Short tileFill) {
@@ -1251,11 +1250,6 @@ public class Converter implements Callable<Integer> {
     // First find which reader class we need
     Class<?> readerClass = getBaseReaderClass();
 
-    if (!readerClass.equals(MiraxReader.class) && fillValue != null) {
-      throw new IllegalArgumentException(
-        "--fill-value not yet supported for " + readerClass);
-    }
-
     // Now with our found type instantiate our queue of readers for use
     // during conversion
     boolean savedMemoFile = false;
@@ -1264,8 +1258,8 @@ public class Converter implements Callable<Integer> {
       Memoizer memoizer;
       try {
         reader = (IFormatReader) readerClass.getConstructor().newInstance();
-        if (fillValue != null && reader instanceof MiraxReader) {
-          ((MiraxReader) reader).setFillValue(fillValue.byteValue());
+        if (fillValue != null) {
+          reader.setFillColor(fillValue.byteValue());
         }
         memoizer = createMemoizer(reader);
       }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/MetaxpressReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MetaxpressReader.java
@@ -114,12 +114,12 @@ public class MetaxpressReader extends FormatReader {
         planeReader.openBytes(0, buf, x, y, w, h);
       }
       catch (IOException e) {
-        Arrays.fill(buf, (byte) 0);
+        Arrays.fill(buf, getFillColor());
       }
       s.stop("openBytes(0) on " + file);
     }
     else {
-      Arrays.fill(buf, (byte) 0);
+      Arrays.fill(buf, getFillColor());
     }
 
     return buf;

--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -131,7 +131,6 @@ public class MiraxReader extends FormatReader {
     JPEG2000CodecOptions.getDefaultOptions();
 
   private boolean fluorescence = false;
-  private Byte fillValue = null;
 
   private transient JPEGXRCodec jpegxrCodec = new JPEGXRCodec();
 
@@ -217,7 +216,7 @@ public class MiraxReader extends FormatReader {
 
     // set background color to black instead of the stored fill color
     // this is to match the default behavior of Pannoramic Viewer
-    Arrays.fill(buf, getFillValue());
+    Arrays.fill(buf, getFillColor());
 
     if (tileCache == null) {
       tileCache = CacheBuilder.newBuilder()
@@ -1057,9 +1056,10 @@ public class MiraxReader extends FormatReader {
    * Set the fill value for missing tiles.
    *
    * @param fill the fill value, or null to use the reader's default value
+   * @deprecated used setFillColor(Byte)
    */
   public void setFillValue(Byte fill) {
-    fillValue = fill;
+    setFillColor(fill);
   }
 
   /**
@@ -1069,10 +1069,17 @@ public class MiraxReader extends FormatReader {
    * for brightfield.
    *
    * @return fill value for missing tiles
+   * @deprecated use getFillColor()
    */
   public byte getFillValue() {
-    if (fillValue != null) {
-      return fillValue;
+    return getFillColor();
+  }
+
+  @Override
+  public Byte getFillColor() {
+    Byte color = getFillColor();
+    if (color != null) {
+      return color;
     }
     return fluorescence ? (byte) 0 : (byte) 255;
   }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -1077,7 +1077,7 @@ public class MiraxReader extends FormatReader {
 
   @Override
   public Byte getFillColor() {
-    Byte color = getFillColor();
+    Byte color = super.getFillColor();
     if (color != null) {
       return color;
     }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/ND2PlateReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/ND2PlateReader.java
@@ -90,7 +90,7 @@ public class ND2PlateReader extends FormatReader {
   public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
     throws FormatException, IOException
   {
-    Arrays.fill(buf, (byte) 0);
+    Arrays.fill(buf, getFillColor());
 
     int fileIndex = getFileIndex(getSeries());
     if (fileIndex >= 0 && fileIndex < files.length) {


### PR DESCRIPTION
...so now this option can be used with all readers.

Noticed while working on #256 that `--fill-value` still only applied to `MiraxReader`. Given that `setFillColor` and `getFillColor` were added to `IFormatReader` in Bio-Formats 6.13.0 (see https://github.com/ome/bioformats/pull/3963), this updates `--fill-value` to make use of this new API. Several of the readers didn't make use of `getFillColor()` in `openBytes`, so that's been fixed too.