### PR TITLE
Add `--no-tiles` option to write metadata only

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -167,6 +167,7 @@ public class Converter implements Callable<Integer> {
   private volatile boolean noRootGroup = false;
   private volatile boolean reuseExistingResolutions = false;
   private volatile int minSize;
+  private volatile boolean writeImageData = true;
 
   /** Scaling implementation that will be used during downsampling. */
   private volatile IImageScaler scaler = new SimpleImageScaler();
@@ -372,6 +373,20 @@ public class Converter implements Callable<Integer> {
     else {
       LOGGER.warn("Ignoring invalid chunk depth: {}", depth);
     }
+  }
+
+  /**
+   * Set whether or not tiles should actually be converted.
+   *
+   * @param noTiles true if tiles should not be converted
+   */
+  @Option(
+    names = {"--no-tiles"},
+    description = "Write all metadata, but do not convert any tiles",
+    defaultValue = "false"
+  )
+  public void setNoTiles(boolean noTiles) {
+    writeImageData = !noTiles;
   }
 
   /**
@@ -928,6 +943,13 @@ public class Converter implements Callable<Integer> {
    */
   public int getChunkDepth() {
     return chunkDepth;
+  }
+
+  /**
+   * @return true if image data will not be converted
+   */
+  public boolean getNoTiles() {
+    return !writeImageData;
   }
 
   /**
@@ -2131,6 +2153,10 @@ public class Converter implements Callable<Integer> {
           .compressor(CompressorFactory.create(
               compressionType.toString(), compressionProperties));
       ZarrArray.create(getRootPath().resolve(resolutionString), arrayParams);
+
+      if (!writeImageData) {
+        continue;
+      }
 
       nTile = new AtomicInteger(0);
       tileCount = resTileCounts[resolution];


### PR DESCRIPTION
Super quick thought on https://github.com/glencoesoftware/omero-zarr-pixel-buffer/pull/11#discussion_r1784080601, but not thoroughly tested. Mostly just to capture the suggestion from @sbesson so we don't forget.