### PR TITLE
MRXS: fix position units and brightfield background color

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -91,7 +91,7 @@ public class MiraxReader extends FormatReader {
 
   // -- Fields --
 
-  private int fillColor;
+  private int channelFillColor;
   private int pyramidDepth;
   private List<String> files = new ArrayList<String>();
   private String iniPath;
@@ -344,7 +344,7 @@ public class MiraxReader extends FormatReader {
       xTiles = 0;
       yTiles = 0;
       divPerSide = 0;
-      fillColor = 0;
+      channelFillColor = 0;
       minColIndex = null;
       maxColIndex = null;
       minRowIndex = null;
@@ -751,7 +751,8 @@ public class MiraxReader extends FormatReader {
         Double.parseDouble(zoomLevel.get("MICROMETER_PER_PIXEL_Y"));
       format.set(i, zoomLevel.get("IMAGE_FORMAT"));
 
-      fillColor = Integer.parseInt(zoomLevel.get("IMAGE_FILL_COLOR_BGR"));
+      channelFillColor =
+        Integer.parseInt(zoomLevel.get("IMAGE_FILL_COLOR_BGR"));
 
       CoreMetadata m = core.get(i);
       m.sizeC = Integer.parseInt(hierarchy.get("HIER_1_COUNT"));
@@ -860,7 +861,7 @@ public class MiraxReader extends FormatReader {
       IMinMaxStore minMax = (IMinMaxStore) store;
       for (int series=0; series<core.get(0).resolutionCount; series++) {
         for (int c=0; c<getEffectiveSizeC(); c++) {
-          int color = (fillColor >> (8 * (c % MAX_CHANNELS))) & 0xff;
+          int color = (channelFillColor >> (8 * (c % MAX_CHANNELS))) & 0xff;
           double percentColor = color / 255.0;
           percentColor *=
             (Math.pow(2, FormatTools.getBytesPerPixel(getPixelType()) * 8) - 1);
@@ -1077,9 +1078,10 @@ public class MiraxReader extends FormatReader {
 
   @Override
   public Byte getFillColor() {
-    Byte color = super.getFillColor();
-    if (color != null) {
-      return color;
+    // don't check super.getFillColor() here, as that is expected to
+    // return 0 instead of null if a fill color was not set
+    if (fillColor != null) {
+      return super.getFillColor();
     }
     return fluorescence ? (byte) 0 : (byte) 255;
   }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -945,11 +945,18 @@ public class MiraxReader extends FormatReader {
       String sizeX = resTable.get("MICROMETER_PER_PIXEL_X");
       String sizeY = resTable.get("MICROMETER_PER_PIXEL_Y");
 
+      // store positions in pixels, but override with value in physical units
+      // if the physical pixel sizes are present and valid
+      store.setPlanePositionX(new Length(originX, UNITS.PIXEL), 0, 0);
+      store.setPlanePositionY(new Length(originY, UNITS.PIXEL), 0, 0);
+
       if (sizeX != null) {
         try {
           double x = Double.parseDouble(sizeX);
           if (x > 0) {
             store.setPixelsPhysicalSizeX(new Length(x, UNITS.MICROM), 0);
+            store.setPlanePositionX(
+              new Length(originX * x, UNITS.MICROM), 0, 0);
           }
         }
         catch (NumberFormatException e) {
@@ -961,15 +968,14 @@ public class MiraxReader extends FormatReader {
           double y = Double.parseDouble(sizeY);
           if (y > 0) {
             store.setPixelsPhysicalSizeY(new Length(y, UNITS.MICROM), 0);
+            store.setPlanePositionY(
+              new Length(originY * y, UNITS.MICROM), 0, 0);
           }
         }
         catch (NumberFormatException e) {
           LOGGER.debug("Could not parse physical pixel size Y {}", sizeY);
         }
       }
-
-      store.setPlanePositionX(new Length(originX, UNITS.PIXEL), 0, 0);
-      store.setPlanePositionY(new Length(originY, UNITS.PIXEL), 0, 0);
 
       // parse channel data
 


### PR DESCRIPTION
As discussed on Friday with @erindiel. Expect to need a raw2ometiff PR as well for the same data, so will assign reviewers once both PRs are open.