### PR TITLE
Make sure the same OMEXMLMetadataRoot is used in all reader MetadataStores

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1390,6 +1390,13 @@ public class Converter implements Callable<Integer> {
       finally {
         readers.put(v);
       }
+      if (meta != null) {
+        final OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) meta.getRoot();
+        readers.forEach((reader) -> {
+          IMetadata workerMeta = (IMetadata) reader.getMetadataStore();
+          workerMeta.setRoot(root);
+        });
+      }
 
       if (!noHCS) {
         scaleFormatString = "%s/%s/%d/%d";


### PR DESCRIPTION
Fixes #269, cc @psobolewskiPhD.

When testing with `--max_workers` greater than 1 somewhere that `Runtime.getRuntime().availableProcessors()` is also greater than 1:

```
$ touch "test&series=3.fake"
$ bin/bioformats2raw -p test\&series\=3.fake test-series1.zarr --series 1
```

The name in `test-series1.zarr/0/0/.zattrs` and the `Name` on the only `Image` in `test-series1.zarr/OME/METADATA.ome.xml` may differ.

Without this change, removing an `Image` or `Plate` from the original OME metadata was only applied to the first worker's reader's `MetadataStore`. The name in each `.zattrs` is taken from an `Image.Name` in the (supposedly) updated `MetadataStore`:

https://github.com/melissalinkert/bioformats2raw/blob/2eccc84321a40698dd8a72ea1f42594dc1095fab/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java#L2430
https://github.com/melissalinkert/bioformats2raw/blob/2eccc84321a40698dd8a72ea1f42594dc1095fab/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java#L2539

...but if the taken reader happens to not be the first one, then original unmodified OME metadata was used resulting in incorrect names.

This change aims to sync the `MetadataStore` contents for all readers, after all `Plate` and `Image` removal but before conversion really starts. This is similar to how the series index is updated for all readers.