### PR TITLE
Replace non-existent `--compression-options` with `--compression-properties`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ By default, output is compressed with Blosc using the `lz4` codec.
 
 To change the overall compression type, use `--compression <type>`. Supported types are `blosc`, `zlib`, and `null` (uncompressed).
 
-To change type-specific options, use `--compression-options <key=value>`.
+To change type-specific options, use `--compression-properties <key=value>`.
 
 Supported options for `blosc` are:
 
@@ -153,12 +153,12 @@ Supported options for `zlib` are:
 
 There are no supported compression options for type `null`, as this is uncompressed data.
 
-While `--compression blosc --compression-options cname=lz4 --compression-options clevel=5` is the default,
+While `--compression blosc --compression-properties cname=lz4 --compression-properties clevel=5` is the default,
 some datasets perform better in time and/or space with different choices. For workflows where the size of the output Zarr,
 total conversion time, and/or time required to decompress a chunk are important, it is a good idea to
 benchmark several different options with the real input data being used. See also the [Performance](#performance) section below.
 
-In some tests, we have found that `--compression blosc --compression-options cname=zstd --compression-options clevel=3`
+In some tests, we have found that `--compression blosc --compression-properties cname=zstd --compression-properties clevel=3`
 may be a reasonable choice if compressed size is more important than conversion or decompression times.
 
 Output Formatting Options
@@ -321,7 +321,7 @@ the following configuration options:
  * `--tile-width`
  * `--tile-height`
  * `--compression`
- * `--compression-options`
+ * `--compression-properties`
 
 On systems with significant I/O bandwidth, particularly SATA or
 NVMe based storage, you may find sharply diminishing returns with high
@@ -337,7 +337,7 @@ The worker count should be set to 1 if the input data requires a Bio-Formats rea
 This is not a common case, but is a known issue with Imaris HDF data in particular.
 
 In general, expect to need to tune the above settings and measure
-relative performance. See the [Compression options section](#compression-options) above for more information on `--compression` and `--compression-options`.
+relative performance. See the [Compression options section](#compression-properties) above for more information on `--compression` and `--compression-properties`.
 
 Metadata caching
 ================

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ The worker count should be set to 1 if the input data requires a Bio-Formats rea
 This is not a common case, but is a known issue with Imaris HDF data in particular.
 
 In general, expect to need to tune the above settings and measure
-relative performance. See the [Compression options section](#compression-properties) above for more information on `--compression` and `--compression-properties`.
+relative performance. See the [Compression options section](#compression-options) above for more information on `--compression` and `--compression-properties`.
 
 Metadata caching
 ================


### PR DESCRIPTION
Fixes #271.

Honestly not sure how I got this documentation so wrong in #262, but the intent is to keep the existing `--compression-properties` defined in https://github.com/glencoesoftware/bioformats2raw/blob/master/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java#L523.