### PR TITLE
Add `--compact` option to reduce array dimensionality

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Axis.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Axis.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2025 Glencoe Software, Inc. All rights reserved.
+ *
+ * This software is distributed under the terms described by the LICENSE.txt
+ * file you can find at the root of the distribution bundle.  If the file is
+ * missing please request a copy by contacting info@glencoesoftware.com
+ */
+package com.glencoesoftware.bioformats2raw;
+
+/**
+ * Describe an axis, including type and dimensions.
+ */
+public class Axis {
+
+  private char type;
+  private int length;
+  private int chunkSize;
+
+  /**
+   * Create a new Axis.
+   *
+   * @param t axis type (e.g. 'X')
+   * @param len axis length
+   * @param chunk chunk length (expected to be in range [1, len])
+   */
+  public Axis(char t, int len, int chunk) {
+    type = t;
+    length = len;
+    chunkSize = chunk;
+  }
+
+  /**
+   * @return axis type (e.g. 'X')
+   */
+  public char getType() {
+    return type;
+  }
+
+  /**
+   * @return axis length
+   */
+  public int getLength() {
+    return length;
+  }
+
+  /**
+   * @return chunk length
+   */
+  public int getChunkSize() {
+    return chunkSize;
+  }
+
+}

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1997,16 +1997,20 @@ public class Converter implements Callable<Integer> {
         dimensionOrder != null? dimensionOrder.toString()
         : reader.getDimensionOrder()).reverse().toString();
 
+    int spatialDims = 0;
     for (char c : o.toCharArray()) {
       switch (c) {
         case 'X':
           axes.add(new Axis(c, scaledWidth, scaledTileWidth));
+          spatialDims++;
           break;
         case 'Y':
           axes.add(new Axis(c, scaledHeight, scaledTileHeight));
+          spatialDims++;
           break;
         case 'Z':
           axes.add(new Axis(c, scaledDepth, scaledChunkDepth));
+          spatialDims++;
           break;
         case 'C':
           axes.add(new Axis(c, sizeC, 1));
@@ -2025,10 +2029,19 @@ public class Converter implements Callable<Integer> {
       for (int a=0; a<axes.size(); a++) {
         Axis axis = axes.get(a);
         if (axis.getLength() == 1) {
+          char type = axis.getType();
+          if (type == 'X' || type == 'Y' || type == 'Z') {
+            spatialDims--;
+          }
           axes.remove(axis);
           a--;
         }
       }
+    }
+
+    if (spatialDims < 2) {
+      throw new IllegalArgumentException("Found " + spatialDims +
+        " spatial dimensions, try again without --compact");
     }
     return axes;
   }


### PR DESCRIPTION
The default behavior should be unchanged, but using the `--compact` option should eliminate any dimension with length 1. As indicated in the test, something like `bioformats2raw --compact "test&sizeZ=3.fake" test.zarr` should end up with a 3D array, instead of a 5D array.

I've done some testing locally, but more testing in particular with non-fake data is in order. Maybe also worth thinking about whether X and Y should always be included, or if there are any other restrictions that should be put on this option.

cc @mabruce @erindiel @joshmoore @dominikl @jburel