### PR TITLE
Do not store zero time increment values in coordinateTransforms

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -2681,7 +2681,13 @@ public class Converter implements Callable<Integer> {
       case 'z':
         return meta.getPixelsPhysicalSizeZ(seriesIndex);
       case 't':
-        return meta.getPixelsTimeIncrement(seriesIndex);
+        Quantity timeIncrement = meta.getPixelsTimeIncrement(seriesIndex);
+        if (timeIncrement != null && timeIncrement.value().doubleValue() > 0) {
+          return meta.getPixelsTimeIncrement(seriesIndex);
+        }
+        else {
+          return null;
+        }
       default:
         return null;
     }


### PR DESCRIPTION
Fixes #280

While the OME model allows any floating point value for the time increment, a 0 value in the scale transformation in the coordinateTransforms can create confusion when interpreted as a downsampling factor between resolutions

Using the sample file provided in the corresponding issue, `bioformats2raw` should produce an OME-Zarr dataset where the `scale` transformation includes a `0.0` value for the time axis.
With this change included, PixelsTimeIncrement values of zero should be ignored and the `scale` arrays should use the default `1.0`