### PR TITLE
MRXS: handle output of newer scanners

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -620,24 +620,6 @@ public class MiraxReader extends FormatReader {
               core.add(m);
             }
           }
-          else {
-            LOGGER.trace("name = {}", name);
-            indexData.seek(nonHierarchicalRoot + (totalCount + q) * 4);
-
-            findDataFileReference(indexData);
-            int nextOffset = indexData.readInt();
-            int length = indexData.readInt();
-            int fileNumber = indexData.readInt();
-            LOGGER.trace("  fileNumber = {}, nextOffset = {}, length = {}",
-              fileNumber, nextOffset, length);
-            try {
-              byte[] positionData = getDecompressedData(fileNumber, nextOffset);
-              LOGGER.trace("  positionData.length = {}", positionData.length);
-              LOGGER.trace("  decomped string = {}", new String(positionData));
-            }
-            catch (Throwable t) {
-            }
-          }
         }
       }
       else if (name.equals("StitchingIntensityLayer")) {


### PR DESCRIPTION
Expected to fix #258.

This does a few things:

- removes the assumption that the first referenced pyramid is the full resolution slide; that fixes the channel count and complete lack of image data
- detects the `StitchingLevelForHWCoord` section, and if present, *ignores* the stored positions for each tile and instead places each tile in a regular grid with no overlap
- adds a bunch of `TRACE` and `DEBUG` logging, in case similar issues come up again

In all test data available, converting to OME-TIFF with this change and latest raw2ometiff then opening in QuPath 0.6.0 does not show any obvious tile boundaries or other stitching errors. More eyes would definitely be useful though.

I have not bothered to clean up the commit history here, in case intermediate commits are useful in future for seeing what was tried and rejected.