### PR TITLE
Do not warn about dimension order if XYZCT

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -907,7 +907,8 @@ public class Converter implements Callable<Integer> {
   public void setDimensionOrder(DimensionOrder order) {
     if (order != DimensionOrder.XYZCT) {
       LOGGER.warn(
-        "--dimension-order is deprecated; OME-NGFF requires XYZCT output order");
+        "--dimension-order is deprecated;" +
+        " OME-NGFF requires XYZCT output order");
       dimensionOrder = order;
     }
     dimensionOrder = order;

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -909,7 +909,6 @@ public class Converter implements Callable<Integer> {
       LOGGER.warn(
         "--dimension-order is deprecated;" +
         " OME-NGFF requires XYZCT output order");
-      dimensionOrder = order;
     }
     dimensionOrder = order;
   }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -905,8 +905,11 @@ public class Converter implements Callable<Integer> {
           defaultValue = "XYZCT"
   )
   public void setDimensionOrder(DimensionOrder order) {
-    LOGGER.warn(
-      "--dimension-order is deprecated; OME-NGFF requires XYZCT output order");
+    if (order != DimensionOrder.XYZCT) {
+      LOGGER.warn(
+        "--dimension-order is deprecated; OME-NGFF requires XYZCT output order");
+      dimensionOrder = order;
+    }
     dimensionOrder = order;
   }
 


### PR DESCRIPTION
Follow-up of #278 noticed while reviewing newer contributions

I missed the testing of the default converter and realised that with `bioformats2raw 0.10.0`, the warning is always printed due to the way we are setting options.

With this change included

```
bioformats2raw test.fake test.zarr
```

should not display a WARNING message but

```
bioformats2raw --dimension-order XYZTC test.fake test.zarr
```

should.

Given the annoyance of the WARNING message, I would be inclined to get this released as `0.10.1`.