### PR TITLE
Use CommandLine.execute() and return exit code

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -3252,7 +3252,8 @@ public class Converter implements Callable<Integer> {
    * @param args command line arguments
    */
   public static void main(String[] args) {
-    CommandLine.call(new Converter(), args);
+    int exitCode = new CommandLine(new Converter()).execute(args);
+    System.exit(exitCode);
   }
 
 }


### PR DESCRIPTION
Fixes #286 

See https://picocli.info/#_exit_code, this should allow the application to return a meaningful exit code on success or failure


Without this PR

```
bioformats2raw test.fake test.zarr --invalid-parameters
echo $?
```

should display the usage but return a `0` exit code. With this PR included, the same command should return a `2` exit code indicating failure.
