### PR TITLE
MCD: swap Channel.Name and Channel.Fluor

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/MCDReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MCDReader.java
@@ -300,8 +300,8 @@ public class MCDReader extends FormatReader {
         // exposes both the name and label (which are often slightly different)
         // and this is the easiest way to do that in OME/OMERO model
         int channelIndex = getPlaneIndex(c);
-        store.setChannelName(channel.name, imageIndex, channelIndex);
-        store.setChannelFluor(channel.label, imageIndex, channelIndex);
+        store.setChannelName(channel.label, imageIndex, channelIndex);
+        store.setChannelFluor(channel.name, imageIndex, channelIndex);
       }
     }
     setSeries(0);


### PR DESCRIPTION
As discussed with @muhanadz / @erindiel / @mabruce / @heather-ashmore.

This just swaps which value goes into the `Name` attribute and which attribute goes into `Fluor`.