### PR TITLE
Set Zarr array fill value to 0 for v2/0.4 data

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -2545,6 +2545,7 @@ public class Converter implements Callable<Integer> {
             .withShape(Utils.toLongArray(arrayShape))
             .withChunks(chunkSizes)
             .withDataType(ZarrTypes.getZarrType(pixelType))
+            .withFillValue(0)
             .withDimensionSeparator(getDimensionSeparator());
 
         // currently uses defaults from jzarr, for easier


### PR DESCRIPTION
Fixes #300.

The default fill value in zarr-java for v3 is 0:

https://github.com/zarr-developers/zarr-java/blob/0.1.0/src/main/java/dev/zarr/zarrjava/v3/ArrayMetadataBuilder.java#L29

but for v2 is null:

https://github.com/zarr-developers/zarr-java/blob/0.1.0/src/main/java/dev/zarr/zarrjava/v2/ArrayMetadataBuilder.java#L18

With this change, converting a file with all 0 pixels should result in no chunk files being created (both default v2 and with `--ngff-version 0.5`). I tested with a blank image created in ImageJ and saved to plain TIFF.

The `--fill-value` option is intentionally not used here since that's passed to the underlying Bio-Formats reader and hadn't previously been used to configure the Zarr array. Open to discussing whether that actually makes sense though.