### PR TITLE
OME-Zarr 0.5: add version to well group attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,14 +221,19 @@ Output Formatting Options
 =========================
 
 By default, the output of `bioformats2raw` will be a
-[Zarr dataset](https://zarr.readthedocs.io/en/stable/spec/v2.html) which follows the
+[Zarr dataset](https://zarr-specs.readthedocs.io/en/latest/specs.html) which follows the
 metadata conventions defined by the
-[OME-NGFF 0.4 specification](https://ngff.openmicroscopy.org/0.4/) including the
-[bioformats2raw.layout specification](https://ngff.openmicroscopy.org/0.4/#bf2raw).
+[version 0.4](https://ngff.openmicroscopy.org/specifications/0.4/) of the OME-Zarr specification including the
+[bioformats2raw.layout specification](https://ngff.openmicroscopy.org/specifications/0.4/#bioformats2raw-layout-transitional).
 
 Several formatting options can be passed to the converter and will result in a Zarr dataset
 that is not compatible with raw2ometiff and does not strictly follow the OME-NGFF
 specification but may be suitable for other applications.
+
+#### --ngff-version
+
+Specifies the version of the [OME-Zarr specification](https://ngff.openmicroscopy.org/specifications/index.html)
+that should be used while writing Zarr. Current supported values are 0.4 and 0.5.
 
 #### --pyramid-name
 

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -2752,6 +2752,7 @@ public class Converter implements Callable<Integer> {
           wellMap.put("images", imageList);
           Attributes columnAttrs = new Attributes();
           columnAttrs.put("well", wellMap);
+          columnAttrs.put("version", getNGFFVersion().toString());
 
           String rowPath = index.getRowPath();
           String columnPath = index.getColumnPath();

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -2752,7 +2752,6 @@ public class Converter implements Callable<Integer> {
           wellMap.put("images", imageList);
           Attributes columnAttrs = new Attributes();
           columnAttrs.put("well", wellMap);
-          columnAttrs.put("version", getNGFFVersion().toString());
 
           String rowPath = index.getRowPath();
           String columnPath = index.getColumnPath();
@@ -2760,6 +2759,7 @@ public class Converter implements Callable<Integer> {
           if (getV3()) {
             Group columnGroup = createGroup(rowPath, columnPath);
             Attributes omeAttrs = new Attributes();
+            columnAttrs.put("version", getNGFFVersion().toString());
             omeAttrs.put("ome", columnAttrs);
             ((dev.zarr.zarrjava.v3.Group) columnGroup).setAttributes(omeAttrs);
           }

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrV3Test.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrV3Test.java
@@ -147,7 +147,18 @@ public class ZarrV3Test extends AbstractZarrTest {
     long[] arrayShape = new long[] {1, 1, 1, 512, 512};
     for (int r=0; r<rowCount; r++) {
       for (int c=0; c<colCount; c++) {
+        Group wellGroup = Group.open(store.resolve(
+          String.valueOf((char) ('A' + r)),
+          String.valueOf(c + 1)));
+        omeAttrs = wellGroup.metadata().attributes.getAttributes("ome");
+        assertEquals(getNGFFVersion(), omeAttrs.get("version"));
+        Map<String, Object> well = (Map<String, Object>) omeAttrs.get("well");
+        List<Map<String, Object>> images =
+          (List<Map<String, Object>>) well.get("images");
+        assertEquals(fieldCount, images.size());
         for (int f=0; f<fieldCount; f++) {
+          Map<String, Object> image = (Map<String, Object>) images.get(f);
+          assertEquals(image.get("path"), String.valueOf(f));
           Array array = Array.open(store.resolve(
             String.valueOf((char) ('A' + r)),
             String.valueOf(c + 1),


### PR DESCRIPTION
Discovered while generating a set of OME-Zarr 0.5 datasets with 0.12.0-rc3, the metadata written for the well group is currently invalid as it is missing a `version` attribute - see e..g https://ome.github.io/ome-ngff-validator/?source=https://gs-public-zarr-dev.s3.amazonaws.com/zarrv3/NIRHTa%252B001.zarr/A/1/

This PR fixes this by:
- populating the attribute storing to include the version as for the other groups
- extending the HCS tests to check the well group attributes: version and well/images

The README is also expanded to cover the multi-version support and the `--ngff-version` option. As this is slightly outside the scope of the initial problem, happy to move the last commit to a dedicated PR if that is preferred.