### PR TITLE
Bump ch.qos.logback:logback-classic from 1.3.16 to 1.5.32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,7 @@ dependencies {
     // implementation 'io.nextflow:nxf-s3fs:1.1.0'
     implementation 'org.lasersonlab:s3fs:2.2.3'
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.16'
-    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.3.16'
-
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.32'
 
     implementation 'org.openpnp:opencv:4.7.0-0'
     implementation 'me.tongfei:progressbar:0.10.2'


### PR DESCRIPTION
With Java 11 being the new runtime requirement and the 1.3.x and 1.4.x series of logback being end of life, this brings the logging implementation the the active 1.5.x series - see https://logback.qos.ch/news.html