### PR TITLE
feat(mirax): add support for fluorescence z-stacks

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -297,7 +297,7 @@ public class MiraxReader extends FormatReader {
           lookupTileForPlane(index, col, row, z, c, lookupCounter);
         if (thisOffset != null) {
           int channel = hasFocusStack() ? getStoredChannel(index, c) :
-            getLegacyStoredChannel(index, no);
+            getSingleLayerStoredChannel(index, no);
           String file = files.get(thisOffset.fileIndex + 1);
           LOGGER.debug("  * got file = {}, offset = {}",
             file, thisOffset.offset);
@@ -513,7 +513,7 @@ public class MiraxReader extends FormatReader {
       parseFocusBlocks(indexData, listOffsets, hierarchy);
     if (!useTilePositionCounterLookup) {
       offsets.clear();
-      parseClassicRootOffsets(indexData, hierarchicalRoot, nHierarchies);
+      parseSingleLayerRootOffsets(indexData, hierarchicalRoot, nHierarchies);
     }
 
     // read offset to barcode image
@@ -1293,7 +1293,7 @@ public class MiraxReader extends FormatReader {
     return true;
   }
 
-  private void parseClassicRootOffsets(RandomAccessInputStream indexData,
+  private void parseSingleLayerRootOffsets(RandomAccessInputStream indexData,
     long hierarchicalRoot, int nHierarchies) throws IOException
   {
     indexData.seek(hierarchicalRoot);
@@ -1525,7 +1525,7 @@ public class MiraxReader extends FormatReader {
     return storedFocusLevels > 1;
   }
 
-  private int getLegacyStoredChannel(int resolution, int plane) {
+  private int getSingleLayerStoredChannel(int resolution, int plane) {
     int channel = plane % MAX_CHANNELS;
     if (fluorescence &&
       (getSizeC() != 2 || format.get(resolution).equals("JPEG")))

--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -13,6 +13,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -73,6 +74,8 @@ public class MiraxReader extends FormatReader {
 
   private static final String SLIDE_DATA = "Slidedat.ini";
   private static final String FILTER_LEVEL = "Slide filter level";
+  private static final String FOCUS_LEVEL = "Microscope focus level";
+  private static final String Z_STACK_LEVEL_PREFIX = "ZStackLevel_";
 
   /**
    * Maximum number of channels in a tile.  The assembled slide can
@@ -136,6 +139,8 @@ public class MiraxReader extends FormatReader {
   private transient JPEGXRCodec jpegxrCodec = new JPEGXRCodec();
 
   private transient Cache<TilePointer, byte[]> tileCache;
+  private int storedFocusLevels = 1;
+  private boolean useTilePositionCounterLookup = false;
 
   // -- Constructor --
 
@@ -214,6 +219,9 @@ public class MiraxReader extends FormatReader {
     throws FormatException, IOException
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+    int[] zct = getZCTCoords(no);
+    int z = zct[0];
+    int c = zct[1];
 
     // set background color to black instead of the stored fill color
     // this is to match the default behavior of Pannoramic Viewer
@@ -254,12 +262,14 @@ public class MiraxReader extends FormatReader {
     for (int row=0; row<rowCount; row++) {
       for (int col=0; col<colCount; col++) {
         Region tileRegion = new Region(0, 0, width, height);
+        int lookupCounter = -1;
         if (tilePositions != null && index == 0) {
           int colIndex = (int) (minColIndex[index] + col * scale);
           int rowIndex = (int) (minRowIndex[index] + row * scale);
           int xp = (int) (colIndex / divPerSide);
           int yp = (int) (rowIndex / divPerSide);
           int tile = yp * (xTiles / divPerSide) + xp;
+          lookupCounter = tile;
           int correctX = colIndex % (int) div;
           int correctY = rowIndex % (int) div;
           LOGGER.debug("row = {}, col = {}, rowIndex = {}, " +
@@ -276,22 +286,18 @@ public class MiraxReader extends FormatReader {
             tileRegion);
           continue;
         }
+        int tileGroup = hasFocusStack() ? getTileGroupForPlane(z, c) :
+          no / MAX_CHANNELS;
         LOGGER.debug("Looking up tile for resolution = {}, x={}, y={}, c={}",
-          index, col, row, no / MAX_CHANNELS);
+          index, col, row, tileGroup);
         LOGGER.debug("  tileRegion = {}", tileRegion);
         LOGGER.debug("  intersection = {}", intersection);
 
-        TilePointer thisOffset = lookupTile(index, col, row, no / MAX_CHANNELS);
+        TilePointer thisOffset =
+          lookupTileForPlane(index, col, row, z, c, lookupCounter);
         if (thisOffset != null) {
-          int channel = no % MAX_CHANNELS;
-          // 2 channel JPEG data needs to have the channel index inverted
-          // 2 channel JPEG-2000 data should not have the channel index inverted
-          if (fluorescence &&
-            (getSizeC() != 2 || format.get(index).equals("JPEG")))
-          {
-            channel = MAX_CHANNELS - channel - 1;
-          }
-
+          int channel = hasFocusStack() ? getStoredChannel(index, c) :
+            getLegacyStoredChannel(index, no);
           String file = files.get(thisOffset.fileIndex + 1);
           LOGGER.debug("  * got file = {}, offset = {}",
             file, thisOffset.offset);
@@ -370,6 +376,8 @@ public class MiraxReader extends FormatReader {
       tilePositions = null;
       pngReader.close();
       fluorescence = false;
+      storedFocusLevels = 1;
+      useTilePositionCounterLookup = false;
     }
   }
 
@@ -453,13 +461,15 @@ public class MiraxReader extends FormatReader {
     files.add(indexFile);
 
     int nHierarchies = Integer.parseInt(hierarchy.get("HIER_COUNT"));
+    int totalHierarchicalValues = 0;
+    for (int i=0; i<nHierarchies; i++) {
+      totalHierarchicalValues +=
+        Integer.parseInt(hierarchy.get("HIER_" + i + "_COUNT"));
+    }
 
     pyramidDepth = Integer.parseInt(hierarchy.get("HIER_0_COUNT"));
 
-    core.clear();
-    for (int i=0; i<pyramidDepth; i++) {
-      core.add(new CoreMetadata());
-    }
+    initializeMainSeries(pyramidDepth);
 
     tileWidth = new int[pyramidDepth];
     tileHeight = new int[pyramidDepth];
@@ -481,97 +491,35 @@ public class MiraxReader extends FormatReader {
       files.add(f.getAbsolutePath());
     }
 
-    int pageSize = Integer.parseInt(hierarchy.get("PAGEELEMENTCOUNT"));
+    storedFocusLevels = getStoredFocusCount(hierarchy);
 
+    int originX = 0;
+    int originY = 0;
+    int metadataWidth = 0;
+    int metadataHeight = 0;
     RandomAccessInputStream indexData = new RandomAccessInputStream(indexFile);
     indexData.order(true);
     indexData.seek(37);
     long hierarchicalRoot = indexData.readInt();
     long nonHierarchicalRoot = indexData.readInt();
     indexData.seek(hierarchicalRoot);
-    long[][] listOffsets = new long[nHierarchies][];
-    for (int i=0; i<listOffsets.length; i++) {
-      listOffsets[i] = new long[pyramidDepth];
-      for (int d=0; d<pyramidDepth; d++) {
-        listOffsets[i][d] = indexData.readInt();
-        LOGGER.trace("Expect {} offsets for hierarchy #{}, level #{}",
-          listOffsets[i][d], i, d);
-      }
+    long[] listOffsets = new long[totalHierarchicalValues];
+    for (int value=0; value<totalHierarchicalValues; value++) {
+      listOffsets[value] = indexData.readInt();
+      LOGGER.trace("Expect {} offsets for value #{}", listOffsets[value], value);
     }
 
-    // read offsets to pyramid pixel data tiles
-    for (int h=0; h<nHierarchies; h++) {
-      for (int i=0; i<listOffsets[h].length; i++) {
-        LOGGER.trace("h = {}, i = {}", h, i);
-        if (i == format.size()) {
-          format.add("");
-        }
-
-        if (listOffsets[h][i] == 0) {
-          LOGGER.trace("Skipping hierarchy #{} level #{}", h, i);
-          continue;
-        }
-        indexData.seek(listOffsets[h][i]);
-        int nItems = indexData.readInt();
-        if (nItems != 0) {
-          LOGGER.trace("First page size should be 0, was " + nItems +
-            "; skipping level " + i + " in hierarchy " + h);
-          continue;
-        }
-        listOffsets[h][i] = indexData.readInt();
-
-        if (listOffsets[h][i] == 0) {
-          LOGGER.trace("Found offset 0 for hierarchy #{} level #{}", h, i);
-          continue;
-        }
-        LOGGER.trace("Reading tile offsets for hierarchy #{} level #{} from {}",
-          h, i, listOffsets[h][i]);
-
-        indexData.seek(listOffsets[h][i]);
-        nItems = indexData.readInt();
-        int nextPointer = indexData.readInt();
-        int nextCounter = indexData.readInt();
-        int itemCounter = 0;
-        while (indexData.getFilePointer() <= indexData.length() - 16) {
-          if (itemCounter == nItems) {
-            if (nextPointer == 0) {
-              break;
-            }
-            indexData.seek(nextPointer);
-            nItems = indexData.readInt();
-            nextPointer = indexData.readInt();
-            nextCounter = indexData.readInt();
-            itemCounter = 0;
-          }
-          long nextOffset = indexData.readInt();
-          int length = indexData.readInt();
-          int fileNumber = indexData.readInt();
-
-          LOGGER.trace("nextOffset = {}, nextCounter = {}, " +
-            "length = {}, fileNumber = {}",
-            nextOffset, nextCounter, length, fileNumber);
-
-          if (i == 0) {
-            TilePointer key = new TilePointer(i, nextCounter);
-            List<TilePointer> resolutionOffsets =
-              getOrCreateResolutionOffsets(key);
-            resolutionOffsets.add(
-              new TilePointer(i, fileNumber, nextOffset, nextCounter, length));
-          }
-          nextCounter = indexData.readInt();
-          itemCounter++;
-        }
-      }
+    useTilePositionCounterLookup =
+      parseFocusBlocks(indexData, listOffsets, hierarchy);
+    if (!useTilePositionCounterLookup) {
+      offsets.clear();
+      parseClassicRootOffsets(indexData, hierarchicalRoot, nHierarchies);
     }
 
     // read offset to barcode image
 
     int nonHierCount = Integer.parseInt(hierarchy.get("NONHIER_COUNT"));
     int totalCount = 0;
-    int originX = 0;
-    int originY = 0;
-    int metadataWidth = 0;
-    int metadataHeight = 0;
     for (int i=0; i<nonHierCount; i++) {
       String name = hierarchy.get("NONHIER_" + i + "_NAME");
       int count = Integer.parseInt(hierarchy.get("NONHIER_" + i + "_COUNT"));
@@ -597,7 +545,7 @@ public class MiraxReader extends FormatReader {
               List<TilePointer> resolutionOffsets =
                   getOrCreateResolutionOffsets(key);
               resolutionOffsets.add(new TilePointer(
-                pyramidDepth, fileNumber, nextOffset, 0, length));
+                pyramidDepth, fileNumber, nextOffset, 0, length, -1));
 
               String section =
                 hierarchy.get("NONHIER_" + i + "_VAL_" + q + "_SECTION");
@@ -826,9 +774,9 @@ public class MiraxReader extends FormatReader {
       CoreMetadata m = core.get(i);
       m.sizeC = getChannelCount(hierarchy);
       m.rgb = false;
-      m.sizeZ = 1;
+      m.sizeZ = getFocusCount(hierarchy);
       m.sizeT = 1;
-      m.imageCount = getSizeZ() * getSizeT() * getSizeC();
+      m.imageCount = m.sizeZ * m.sizeT * m.sizeC;
       m.dimensionOrder = "XYCZT";
 
       minRowIndex[i] = Integer.MAX_VALUE;
@@ -1055,6 +1003,10 @@ public class MiraxReader extends FormatReader {
         catch (NumberFormatException e) {
           LOGGER.debug("Could not parse physical pixel size Y {}", sizeY);
         }
+      }
+      Double zStep = getFocusStepMicrometers(hierarchy, data);
+      if (zStep != null && zStep > 0) {
+        store.setPixelsPhysicalSizeZ(new Length(zStep, UNITS.MICROM), 0);
       }
 
       // parse channel data
@@ -1284,26 +1236,303 @@ public class MiraxReader extends FormatReader {
   }
 
   private int getSlideHierarchyIndex(IniTable hierarchy) {
-    int hierarchyIndex = 1;
-    String nameKey = "HIER_%d_NAME";
+    // start at 1: HIER_0 is always the zoom hierarchy, never the filter level
+    return getHierarchyIndex(hierarchy, FILTER_LEVEL, 1, -1);
+  }
 
-    int hierCount = Integer.parseInt(hierarchy.get("HIER_COUNT"));
-    for (int i=hierarchyIndex; i<hierCount; i++) {
-      if (hierarchy.get(String.format(nameKey, i)).equals(FILTER_LEVEL)) {
-        hierarchyIndex = i;
-        break;
+  private boolean parseFocusBlocks(RandomAccessInputStream indexData,
+    long[] listOffsets, IniTable hierarchy) throws IOException
+  {
+    int sizeC = getChannelCount(hierarchy);
+    int focusHierarchyIndex = getHierarchyIndex(hierarchy, FOCUS_LEVEL, -1);
+    int channelGroups = (int) Math.ceil((double) sizeC / MAX_CHANNELS);
+    if (!fluorescence || storedFocusLevels <= 1 || focusHierarchyIndex < 0 ||
+      listOffsets.length < channelGroups * pyramidDepth)
+    {
+      return false;
+    }
+
+    long[][] blockOffsets = new long[channelGroups][pyramidDepth];
+    for (int group=0; group<channelGroups; group++) {
+      for (int resolution=0; resolution<pyramidDepth; resolution++) {
+        long blockOffset = listOffsets[(group * pyramidDepth) + resolution];
+        if (blockOffset == 0) {
+          return false;
+        }
+        blockOffsets[group][resolution] = blockOffset;
       }
     }
 
-    return hierarchyIndex;
+    int[] zStackSlots = new int[storedFocusLevels];
+    int zStackCount = 0;
+    for (int slot=0; slot<storedFocusLevels; slot++) {
+      String levelName = hierarchy.get(String.format(
+        "HIER_%d_VAL_%d", focusHierarchyIndex, slot));
+      if (isZStackLevel(levelName)) {
+        zStackSlots[zStackCount++] = slot;
+      }
+    }
+
+    for (int resolution=0; resolution<pyramidDepth; resolution++) {
+      for (int zIndex=0; zIndex<zStackCount; zIndex++) {
+        int slot = zStackSlots[zIndex];
+        for (int group=0; group<channelGroups; group++) {
+          long pageRecordOffset = blockOffsets[group][resolution] + (slot * 8L);
+          indexData.seek(pageRecordOffset);
+          int recordCount = indexData.readInt();
+          long pageOffset = indexData.readInt();
+          if (recordCount != 0 || pageOffset == 0) {
+            LOGGER.trace("Unexpected focus block record at {}: count={}, pageOffset={}",
+              pageRecordOffset, recordCount, pageOffset);
+            return false;
+          }
+          addPageOffsets(indexData, pageOffset, resolution, zIndex);
+        }
+      }
+    }
+    return true;
+  }
+
+  private void parseClassicRootOffsets(RandomAccessInputStream indexData,
+    long hierarchicalRoot, int nHierarchies) throws IOException
+  {
+    indexData.seek(hierarchicalRoot);
+    long[][] hierarchyOffsets = new long[nHierarchies][];
+    for (int h=0; h<nHierarchies; h++) {
+      hierarchyOffsets[h] = new long[pyramidDepth];
+      for (int resolution=0; resolution<pyramidDepth; resolution++) {
+        hierarchyOffsets[h][resolution] = indexData.readInt();
+        LOGGER.trace("Expect {} offsets for hierarchy #{}, level #{}",
+          hierarchyOffsets[h][resolution], h, resolution);
+      }
+    }
+
+    for (int h=0; h<nHierarchies; h++) {
+      for (int resolution=0; resolution<pyramidDepth; resolution++) {
+        if (hierarchyOffsets[h][resolution] == 0) {
+          LOGGER.trace("Skipping hierarchy #{} level #{}", h, resolution);
+          continue;
+        }
+        indexData.seek(hierarchyOffsets[h][resolution]);
+        int nItems = indexData.readInt();
+        if (nItems != 0) {
+          LOGGER.trace("First page size should be 0, was {}; skipping level {} in hierarchy {}",
+            nItems, resolution, h);
+          continue;
+        }
+        long pageOffset = indexData.readInt();
+        if (pageOffset == 0) {
+          LOGGER.trace("Found offset 0 for hierarchy #{} level #{}", h, resolution);
+          continue;
+        }
+        LOGGER.trace("Reading tile offsets for hierarchy #{} level #{} from {}",
+          h, resolution, pageOffset);
+        if (resolution == 0) {
+          addPageOffsets(indexData, pageOffset, resolution, h);
+        }
+      }
+    }
+  }
+
+  private void addPageOffsets(RandomAccessInputStream indexData, long pageOffset,
+    int resolution, int sourceValue) throws IOException
+  {
+    indexData.seek(pageOffset);
+    int nItems = indexData.readInt();
+    int nextPointer = indexData.readInt();
+    int nextCounter = indexData.readInt();
+    int itemCounter = 0;
+    while (indexData.getFilePointer() <= indexData.length() - 16) {
+      if (itemCounter == nItems) {
+        if (nextPointer == 0) {
+          break;
+        }
+        indexData.seek(nextPointer);
+        nItems = indexData.readInt();
+        nextPointer = indexData.readInt();
+        nextCounter = indexData.readInt();
+        itemCounter = 0;
+      }
+      long nextOffset = indexData.readInt();
+      int length = indexData.readInt();
+      int fileNumber = indexData.readInt();
+
+      TilePointer key = new TilePointer(resolution, nextCounter);
+      List<TilePointer> resolutionOffsets = getOrCreateResolutionOffsets(key);
+      resolutionOffsets.add(
+        new TilePointer(resolution, fileNumber, nextOffset, nextCounter, length,
+          sourceValue));
+      nextCounter = indexData.readInt();
+      itemCounter++;
+    }
   }
 
   private int getChannelCount(IniTable hierarchy) {
     int hierarchyIndex = getSlideHierarchyIndex(hierarchy);
-    String countKey = "HIER_%d_COUNT";
-
-    String channelKey = String.format(countKey, hierarchyIndex);
+    if (hierarchyIndex < 0) {
+      LOGGER.warn("Missing filter hierarchy; defaulting channel count to 1");
+      return 1;
+    }
+    String channelKey = String.format("HIER_%d_COUNT", hierarchyIndex);
     return Integer.parseInt(hierarchy.get(channelKey));
+  }
+
+
+  int getFocusCount(IniTable hierarchy) {
+    int storedLevels = getStoredFocusCount(hierarchy);
+    int hierarchyIndex = getHierarchyIndex(hierarchy, FOCUS_LEVEL, -1);
+    if (hierarchyIndex < 0 || storedLevels <= 1) {
+      return 1;
+    }
+    int focusLevels = 0;
+    for (int i=0; i<storedLevels; i++) {
+      String levelName = hierarchy.get(String.format(
+        "HIER_%d_VAL_%d", hierarchyIndex, i));
+      if (isZStackLevel(levelName)) {
+        focusLevels++;
+      }
+    }
+    return focusLevels == 0 ? 1 : focusLevels;
+  }
+
+
+  int getStoredFocusCount(IniTable hierarchy) {
+    int hierarchyIndex = getHierarchyIndex(hierarchy, FOCUS_LEVEL, -1);
+    if (hierarchyIndex < 0) {
+      return 1;
+    }
+    String countValue = hierarchy.get(String.format("HIER_%d_COUNT", hierarchyIndex));
+    if (countValue == null) {
+      LOGGER.warn("Missing focus hierarchy count for HIER_{}", hierarchyIndex);
+      return 1;
+    }
+    try {
+      return Integer.parseInt(countValue);
+    }
+    catch (NumberFormatException e) {
+      LOGGER.warn("Could not parse focus hierarchy count: {}", countValue);
+      return 1;
+    }
+  }
+
+
+  Double getFocusStepMicrometers(IniTable hierarchy, IniList data) {
+    int storedLevels = getStoredFocusCount(hierarchy);
+    int hierarchyIndex = getHierarchyIndex(hierarchy, FOCUS_LEVEL, -1);
+    if (hierarchyIndex < 0 || storedLevels <= 1) {
+      return null;
+    }
+
+    Double previousOffset = null;
+    for (int i=0; i<storedLevels; i++) {
+      String levelName = hierarchy.get(String.format(
+        "HIER_%d_VAL_%d", hierarchyIndex, i));
+      if (!isZStackLevel(levelName)) {
+        continue;
+      }
+
+      String section = hierarchy.get(String.format(
+        "HIER_%d_VAL_%d_SECTION", hierarchyIndex, i));
+      IniTable focusTable = data.getTable(section);
+      if (focusTable == null) {
+        continue;
+      }
+
+      String offsetValue = focusTable.get("OFFSET_IN_MICROMETERS");
+      if (offsetValue == null) {
+        continue;
+      }
+
+      try {
+        double offset = Double.parseDouble(offsetValue);
+        if (previousOffset != null) {
+          double step = Math.abs(offset - previousOffset);
+          if (step > 0) {
+            return step;
+          }
+        }
+        previousOffset = offset;
+      }
+      catch (NumberFormatException e) {
+        LOGGER.debug("Could not parse focus offset {}", offsetValue);
+      }
+    }
+    return null;
+  }
+
+
+  static int getTileGroup(int z, int c, int sizeC) {
+    int channelGroups = (int) Math.ceil((double) sizeC / MAX_CHANNELS);
+    return (z * channelGroups) + (c / MAX_CHANNELS);
+  }
+
+  int getStoredChannel(int resolution, int c) {
+    int channelGroup = c / MAX_CHANNELS;
+    int channel = c % MAX_CHANNELS;
+    int storedChannels =
+      Math.min(MAX_CHANNELS, getSizeC() - (channelGroup * MAX_CHANNELS));
+    if (fluorescence &&
+      (storedChannels != 2 || format.get(resolution).equals("JPEG")))
+    {
+      return storedChannels - channel - 1;
+    }
+    return channel;
+  }
+
+  void initializeMainSeries(int pyramidDepth) {
+    core.clear();
+    format.clear();
+    for (int i=0; i<pyramidDepth; i++) {
+      core.add(new CoreMetadata());
+      format.add("");
+    }
+  }
+
+  private int getTileGroupForPlane(int z, int c) {
+    return getTileGroup(z, c, getSizeC());
+  }
+
+  TilePointer lookupTileForPlane(int resolution, int col, int row,
+    int z, int c, int lookupCounter)
+  {
+    int tileGroup = getTileGroupForPlane(z, c);
+    return useTilePositionCounterLookup && lookupCounter >= 0 ?
+      lookupTileByCounter(resolution, lookupCounter, tileGroup) :
+      lookupTile(resolution, col, row, tileGroup);
+  }
+
+  private boolean isZStackLevel(String levelName) {
+    return levelName != null && levelName.startsWith(Z_STACK_LEVEL_PREFIX);
+  }
+
+  private int getHierarchyIndex(IniTable hierarchy, String name, int fallback) {
+    return getHierarchyIndex(hierarchy, name, 0, fallback);
+  }
+
+  private int getHierarchyIndex(IniTable hierarchy, String name,
+      int startIndex, int fallback)
+  {
+    int hierCount = Integer.parseInt(hierarchy.get("HIER_COUNT"));
+    for (int i=startIndex; i<hierCount; i++) {
+      if (name.equals(hierarchy.get(String.format("HIER_%d_NAME", i)))) {
+        return i;
+      }
+    }
+    return fallback;
+  }
+
+  private boolean hasFocusStack() {
+    return storedFocusLevels > 1;
+  }
+
+  private int getLegacyStoredChannel(int resolution, int plane) {
+    int channel = plane % MAX_CHANNELS;
+    if (fluorescence &&
+      (getSizeC() != 2 || format.get(resolution).equals("JPEG")))
+    {
+      channel = MAX_CHANNELS - channel - 1;
+    }
+    return channel;
   }
 
   private TilePointer lookupTile(int resolution, int x, int y, int c) {
@@ -1314,6 +1543,10 @@ public class MiraxReader extends FormatReader {
         minRowIndex[resolution] * xTiles + minColIndex[resolution];
       counter = firstTile + resScale * (y * xTiles + x);
     }
+    return lookupTileByCounter(resolution, counter, c);
+  }
+
+  private TilePointer lookupTileByCounter(int resolution, int counter, int c) {
     TilePointer key = new TilePointer(resolution, counter);
     List<TilePointer> channelOffsets = offsets.get(key);
     if (channelOffsets == null || c >= channelOffsets.size()) {
@@ -1321,10 +1554,8 @@ public class MiraxReader extends FormatReader {
     }
     // there may be an extra invalid tile defined (for fluorescence data)
     // skip over it in favor of the correct tile
-    // not sure if there is a better way to detect this case,
-    // so this logic might need improving in the future
     int expectedOffsetCount =
-      (int) Math.ceil((double) getSizeC() / MAX_CHANNELS);
+      getTileGroup(storedFocusLevels - 1, getSizeC() - 1, getSizeC()) + 1;
     if (channelOffsets.size() > expectedOffsetCount && c > 0) {
       return channelOffsets.get(
         c + (channelOffsets.size() - expectedOffsetCount));
@@ -1412,6 +1643,7 @@ public class MiraxReader extends FormatReader {
     public final long offset;
     public final int counter;
     public final int length;
+    public final int sourceValue;
 
     /**
      * Tile pointer to a tile at a given logical offset at a given resolution.
@@ -1419,7 +1651,7 @@ public class MiraxReader extends FormatReader {
      * @param tileCounter logical offset of the tile
      */
     public TilePointer(int res, int tileCounter) {
-      this(res, 0, 0, tileCounter, 0);
+      this(res, 0, 0, tileCounter, 0, -1);
     }
 
     /**
@@ -1434,40 +1666,58 @@ public class MiraxReader extends FormatReader {
     public TilePointer(int res, int index, long tileOffset, int tileCounter,
       int length)
     {
+      this(res, index, tileOffset, tileCounter, length, -1);
+    }
+
+    /**
+     * Tile pointer with source hierarchy value preserved for debugging and
+     * stream classification.
+     * @param res resolution the file is at
+     * @param index physical index within the file
+     * @param tileOffset physical offset within the file
+     * @param tileCounter logical offset of the tile
+     * @param length number of valid bytes starting at tileOffset
+     * @param source hierarchy value index that produced this pointer, or -1
+     */
+    public TilePointer(int res, int index, long tileOffset, int tileCounter,
+      int length, int source)
+    {
       this.resolution = res;
       this.fileIndex = index;
       this.offset = tileOffset;
       this.counter = tileCounter;
       this.length = length;
+      this.sourceValue = source;
     }
 
     @Override
     public int compareTo(TilePointer o) {
-      if (equals(o)) {
-        return 0;
-      }
       if (o.resolution != this.resolution) {
-        return this.resolution - o.resolution;
+        return Integer.compare(this.resolution, o.resolution);
       }
       if (o.counter != this.counter) {
-        return this.counter - o.counter;
+        return Integer.compare(this.counter, o.counter);
       }
       if (o.fileIndex != this.fileIndex) {
-        return this.fileIndex - o.fileIndex;
+        return Integer.compare(this.fileIndex, o.fileIndex);
+      }
+      if (o.sourceValue != this.sourceValue) {
+        return Integer.compare(this.sourceValue, o.sourceValue);
       }
       if (this.offset != o.offset) {
         return this.offset < o.offset ? -1 : 1;
       }
-      if (this.length < o.length) {
-        return -1;
+      if (this.length != o.length) {
+        return Integer.compare(this.length, o.length);
       }
-      return 1;
+      return 0;
     }
 
     @Override
     public String toString() {
       return "resolution=" + resolution + ", fileIndex=" + fileIndex +
-        ", offset=" + offset + ", counter=" + counter;
+        ", offset=" + offset + ", counter=" + counter +
+        ", sourceValue=" + sourceValue;
     }
 
     @Override
@@ -1478,14 +1728,15 @@ public class MiraxReader extends FormatReader {
             && tilePointer.fileIndex == this.fileIndex
             && tilePointer.offset == this.offset
             && tilePointer.counter == this.counter
-            && tilePointer.length == this.length;
+            && tilePointer.length == this.length
+            && tilePointer.sourceValue == this.sourceValue;
       }
       return super.equals(obj);
     }
 
     @Override
     public int hashCode() {
-      return counter;
+      return Objects.hash(resolution, fileIndex, offset, counter, length, sourceValue);
     }
   }
 

--- a/src/test/java/com/glencoesoftware/bioformats2raw/MiraxReaderTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/MiraxReaderTest.java
@@ -189,7 +189,7 @@ public class MiraxReaderTest {
   }
 
   @Test
-  public void testLegacyStoredChannelKeepsOriginalNonStackBehavior()
+  public void testSingleLayerStoredChannelKeepsOriginalNonStackBehavior()
     throws Exception
   {
     MiraxReader reader = new MiraxReader();
@@ -204,7 +204,7 @@ public class MiraxReaderTest {
     setSuperclassField(reader, "core", core);
 
     Method method = MiraxReader.class.getDeclaredMethod(
-      "getLegacyStoredChannel", int.class, int.class);
+      "getSingleLayerStoredChannel", int.class, int.class);
     method.setAccessible(true);
 
     assertEquals(2, method.invoke(reader, 0, 0));
@@ -275,9 +275,9 @@ public class MiraxReaderTest {
       (TreeMap<MiraxReader.TilePointer, List<MiraxReader.TilePointer>>) getField(
         reader, "offsets");
 
-    List<MiraxReader.TilePointer> classicTile = new java.util.ArrayList<>();
-    classicTile.add(reader.new TilePointer(0, 1, 10, 32, 5));
-    offsets.put(reader.new TilePointer(0, 32), classicTile);
+    List<MiraxReader.TilePointer> singleLayerTile = new java.util.ArrayList<>();
+    singleLayerTile.add(reader.new TilePointer(0, 1, 10, 32, 5));
+    offsets.put(reader.new TilePointer(0, 32), singleLayerTile);
 
     List<MiraxReader.TilePointer> tilePositionTile = new java.util.ArrayList<>();
     tilePositionTile.add(reader.new TilePointer(0, 1, 20, 999, 5));
@@ -470,20 +470,20 @@ public class MiraxReaderTest {
   }
 
   @Test
-  public void testParseClassicRootOffsetsSkipsNonZeroResolutions()
+  public void testParseSingleLayerRootOffsetsSkipsNonZeroResolutions()
     throws Exception
   {
     MiraxReader reader = new MiraxReader();
     setField(reader, "pyramidDepth", 2);
     setField(reader, "offsets", new TreeMap<>());
 
-    byte[] bytes = createClassicRootIndex();
+    byte[] bytes = createSingleLayerRootIndex();
     try (RandomAccessInputStream indexData =
       new RandomAccessInputStream(new ByteArrayHandle(bytes)))
     {
       indexData.order(true);
       Method method = MiraxReader.class.getDeclaredMethod(
-        "parseClassicRootOffsets", RandomAccessInputStream.class, long.class,
+        "parseSingleLayerRootOffsets", RandomAccessInputStream.class, long.class,
         int.class);
       method.setAccessible(true);
       method.invoke(reader, indexData, 8L, 1);
@@ -596,7 +596,7 @@ public class MiraxReaderTest {
     return buffer.array();
   }
 
-  private static byte[] createClassicRootIndex() {
+  private static byte[] createSingleLayerRootIndex() {
     ByteBuffer buffer = ByteBuffer.allocate(128).order(ByteOrder.LITTLE_ENDIAN);
 
     buffer.position(8);

--- a/src/test/java/com/glencoesoftware/bioformats2raw/MiraxReaderTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/MiraxReaderTest.java
@@ -1,0 +1,686 @@
+package com.glencoesoftware.bioformats2raw;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
+
+import loci.common.ByteArrayHandle;
+import loci.common.IniList;
+import loci.common.IniTable;
+import loci.common.RandomAccessInputStream;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatReader;
+
+public class MiraxReaderTest {
+
+  @Test
+  public void testSlideHierarchyIndexFindsFilterLevelAfterFocusLevel()
+    throws Exception
+  {
+    IniTable hierarchy = new IniTable();
+    hierarchy.put("HIER_COUNT", "4");
+    hierarchy.put("HIER_0_NAME", "Slide zoom level");
+    hierarchy.put("HIER_1_NAME", "Microscope focus level");
+    hierarchy.put("HIER_2_NAME", "Slide filter level");
+    hierarchy.put("HIER_2_COUNT", "4");
+    hierarchy.put("HIER_3_NAME", "Ignored hierarchy");
+
+    MiraxReader reader = new MiraxReader();
+    Method method = MiraxReader.class.getDeclaredMethod(
+      "getSlideHierarchyIndex", IniTable.class);
+    method.setAccessible(true);
+
+    assertEquals(2, method.invoke(reader, hierarchy));
+  }
+
+  @Test
+  public void testChannelCountUsesResolvedFilterHierarchy() throws Exception {
+    IniTable hierarchy = new IniTable();
+    hierarchy.put("HIER_COUNT", "4");
+    hierarchy.put("HIER_0_NAME", "Slide zoom level");
+    hierarchy.put("HIER_1_NAME", "Microscope focus level");
+    hierarchy.put("HIER_2_NAME", "Slide filter level");
+    hierarchy.put("HIER_2_COUNT", "4");
+    hierarchy.put("HIER_3_NAME", "Ignored hierarchy");
+
+    MiraxReader reader = new MiraxReader();
+    Method method = MiraxReader.class.getDeclaredMethod(
+      "getChannelCount", IniTable.class);
+    method.setAccessible(true);
+
+    assertEquals(4, method.invoke(reader, hierarchy));
+  }
+
+  @Test
+  public void testChannelCountDefaultsWithoutFilterHierarchy()
+    throws Exception
+  {
+    IniTable hierarchy = new IniTable();
+    hierarchy.put("HIER_COUNT", "1");
+    hierarchy.put("HIER_0_NAME", "Slide zoom level");
+
+    MiraxReader reader = new MiraxReader();
+    Method method = MiraxReader.class.getDeclaredMethod(
+      "getChannelCount", IniTable.class);
+    method.setAccessible(true);
+
+    assertEquals(1, method.invoke(reader, hierarchy));
+  }
+
+  @Test
+  public void testFocusCountExcludesNonZStackLevels() {
+    IniTable hierarchy = new IniTable();
+    hierarchy.put("HIER_COUNT", "3");
+    hierarchy.put("HIER_0_NAME", "Slide zoom level");
+    hierarchy.put("HIER_1_NAME", "Slide filter level");
+    hierarchy.put("HIER_2_NAME", "Microscope focus level");
+    hierarchy.put("HIER_2_COUNT", "26");
+    hierarchy.put("HIER_2_VAL_0", "ExtFocusLevel");
+    for (int i=1; i<26; i++) {
+      hierarchy.put("HIER_2_VAL_" + i, "ZStackLevel_(" + (i - 13) + ")");
+    }
+
+    MiraxReader reader = new MiraxReader();
+    assertEquals(25, reader.getFocusCount(hierarchy));
+  }
+
+  @Test
+  public void testMissingFocusHierarchyDefaultsToSinglePlane() {
+    IniTable hierarchy = new IniTable();
+    hierarchy.put("HIER_COUNT", "2");
+    hierarchy.put("HIER_0_NAME", "Slide zoom level");
+    hierarchy.put("HIER_1_NAME", "Slide filter level");
+
+    MiraxReader reader = new MiraxReader();
+    assertEquals(1, reader.getFocusCount(hierarchy));
+  }
+
+  @Test
+  public void testInitializeMainSeriesKeepsFormatAlignedWithCore()
+    throws Exception
+  {
+    MiraxReader reader = new MiraxReader();
+    Field coreField = FormatReader.class.getDeclaredField("core");
+    coreField.setAccessible(true);
+    coreField.set(reader, new ArrayList<CoreMetadata>());
+    reader.initializeMainSeries(10);
+
+    @SuppressWarnings("unchecked")
+    List<String> format = (List<String>) getField(reader, "format");
+    @SuppressWarnings("unchecked")
+    List<CoreMetadata> core = (List<CoreMetadata>) coreField.get(reader);
+
+    assertEquals(10, format.size());
+    assertEquals(10, core.size());
+    assertTrue(format.stream().allMatch(String::isEmpty));
+  }
+
+  @Test
+  public void testTileGroupWithVariousChannelCounts() {
+    // sizeC=1: single channel, one group per Z
+    assertEquals(0, MiraxReader.getTileGroup(0, 0, 1));
+    assertEquals(1, MiraxReader.getTileGroup(1, 0, 1));
+    // sizeC=3: exactly MAX_CHANNELS, all channels in one group
+    assertEquals(0, MiraxReader.getTileGroup(0, 0, 3));
+    assertEquals(0, MiraxReader.getTileGroup(0, 2, 3));
+    assertEquals(1, MiraxReader.getTileGroup(1, 0, 3));
+    // sizeC=7: two full groups + one partial = 3 groups per Z
+    assertEquals(0, MiraxReader.getTileGroup(0, 0, 7));
+    assertEquals(1, MiraxReader.getTileGroup(0, 3, 7));
+    assertEquals(2, MiraxReader.getTileGroup(0, 6, 7));
+    assertEquals(3, MiraxReader.getTileGroup(1, 0, 7));
+  }
+
+  @Test
+  public void testStoredChannelHandlesPartialJpeg2000Groups()
+    throws Exception
+  {
+    MiraxReader reader = new MiraxReader();
+    setField(reader, "fluorescence", true);
+    setField(reader, "format", java.util.Arrays.asList("JPEG2000"));
+    setSuperclassField(reader, "currentId", "synthetic");
+    java.util.List<CoreMetadata> core = new java.util.ArrayList<>();
+    CoreMetadata metadata = new CoreMetadata();
+    metadata.sizeC = 4;
+    core.add(metadata);
+    setSuperclassField(reader, "core", core);
+
+    assertEquals(2, reader.getStoredChannel(0, 0));
+    assertEquals(1, reader.getStoredChannel(0, 1));
+    assertEquals(0, reader.getStoredChannel(0, 2));
+    assertEquals(0, reader.getStoredChannel(0, 3));
+
+    metadata.sizeC = 5;
+    assertEquals(2, reader.getStoredChannel(0, 0));
+    assertEquals(1, reader.getStoredChannel(0, 1));
+    assertEquals(0, reader.getStoredChannel(0, 2));
+    assertEquals(0, reader.getStoredChannel(0, 3));
+    assertEquals(1, reader.getStoredChannel(0, 4));
+  }
+
+  @Test
+  public void testStoredChannelKeepsTwoChannelJpeg2000Order()
+    throws Exception
+  {
+    MiraxReader reader = new MiraxReader();
+    setField(reader, "fluorescence", true);
+    setField(reader, "format", java.util.Arrays.asList("JPEG2000"));
+    setSuperclassField(reader, "currentId", "synthetic");
+    java.util.List<CoreMetadata> core = new java.util.ArrayList<>();
+    CoreMetadata metadata = new CoreMetadata();
+    metadata.sizeC = 2;
+    core.add(metadata);
+    setSuperclassField(reader, "core", core);
+
+    assertEquals(0, reader.getStoredChannel(0, 0));
+    assertEquals(1, reader.getStoredChannel(0, 1));
+  }
+
+  @Test
+  public void testLegacyStoredChannelKeepsOriginalNonStackBehavior()
+    throws Exception
+  {
+    MiraxReader reader = new MiraxReader();
+    setField(reader, "fluorescence", true);
+    setField(reader, "format", java.util.Arrays.asList("JPEG"));
+    setSuperclassField(reader, "currentId", "synthetic");
+
+    java.util.List<CoreMetadata> core = new java.util.ArrayList<>();
+    CoreMetadata metadata = new CoreMetadata();
+    metadata.sizeC = 5;
+    core.add(metadata);
+    setSuperclassField(reader, "core", core);
+
+    Method method = MiraxReader.class.getDeclaredMethod(
+      "getLegacyStoredChannel", int.class, int.class);
+    method.setAccessible(true);
+
+    assertEquals(2, method.invoke(reader, 0, 0));
+    assertEquals(1, method.invoke(reader, 0, 1));
+    assertEquals(0, method.invoke(reader, 0, 2));
+    assertEquals(2, method.invoke(reader, 0, 3));
+    assertEquals(1, method.invoke(reader, 0, 4));
+  }
+
+  @Test
+  public void testLookupTileSkipsExtraFluorescenceTile() throws Exception {
+    MiraxReader reader = new MiraxReader();
+    setField(reader, "fluorescence", true);
+    setField(reader, "offsets", new TreeMap<>());
+    setField(reader, "pyramidDepth", 1);
+    setField(reader, "minRowIndex", new int[] {0});
+    setField(reader, "minColIndex", new int[] {0});
+    setField(reader, "xTiles", 1);
+    setSuperclassField(reader, "currentId", "synthetic");
+    java.util.List<CoreMetadata> core = new java.util.ArrayList<>();
+    CoreMetadata metadata = new CoreMetadata();
+    metadata.sizeC = 4;
+    core.add(metadata);
+    setSuperclassField(reader, "core", core);
+
+    @SuppressWarnings("unchecked")
+    TreeMap<MiraxReader.TilePointer, List<MiraxReader.TilePointer>> offsets =
+      (TreeMap<MiraxReader.TilePointer, List<MiraxReader.TilePointer>>) getField(
+        reader, "offsets");
+
+    MiraxReader.TilePointer key = reader.new TilePointer(0, 0);
+    List<MiraxReader.TilePointer> tiles = new java.util.ArrayList<>();
+    tiles.add(reader.new TilePointer(0, 1, 10, 0, 5));
+    tiles.add(reader.new TilePointer(0, 1, 20, 0, 5));
+    tiles.add(reader.new TilePointer(0, 1, 30, 0, 5));
+    offsets.put(key, tiles);
+
+    Method method = MiraxReader.class.getDeclaredMethod(
+      "lookupTile", int.class, int.class, int.class, int.class);
+    method.setAccessible(true);
+
+    MiraxReader.TilePointer tile =
+      (MiraxReader.TilePointer) method.invoke(reader, 0, 0, 0, 1);
+    assertNotNull(tile);
+    assertEquals(30, tile.offset);
+  }
+
+  @Test
+  public void testLookupTileForPlaneRespectsCounterLookupFlag()
+    throws Exception
+  {
+    MiraxReader reader = new MiraxReader();
+    setField(reader, "offsets", new TreeMap<>());
+    setField(reader, "pyramidDepth", 1);
+    setField(reader, "minRowIndex", new int[] {0});
+    setField(reader, "minColIndex", new int[] {0});
+    setField(reader, "xTiles", 10);
+    setSuperclassField(reader, "currentId", "synthetic");
+
+    java.util.List<CoreMetadata> core = new java.util.ArrayList<>();
+    CoreMetadata metadata = new CoreMetadata();
+    metadata.sizeC = 3;
+    core.add(metadata);
+    setSuperclassField(reader, "core", core);
+
+    @SuppressWarnings("unchecked")
+    TreeMap<MiraxReader.TilePointer, List<MiraxReader.TilePointer>> offsets =
+      (TreeMap<MiraxReader.TilePointer, List<MiraxReader.TilePointer>>) getField(
+        reader, "offsets");
+
+    List<MiraxReader.TilePointer> classicTile = new java.util.ArrayList<>();
+    classicTile.add(reader.new TilePointer(0, 1, 10, 32, 5));
+    offsets.put(reader.new TilePointer(0, 32), classicTile);
+
+    List<MiraxReader.TilePointer> tilePositionTile = new java.util.ArrayList<>();
+    tilePositionTile.add(reader.new TilePointer(0, 1, 20, 999, 5));
+    offsets.put(reader.new TilePointer(0, 999), tilePositionTile);
+
+    setField(reader, "useTilePositionCounterLookup", false);
+    MiraxReader.TilePointer tile =
+      reader.lookupTileForPlane(0, 2, 3, 0, 0, 999);
+    assertNotNull(tile);
+    assertEquals(10, tile.offset);
+
+    setField(reader, "useTilePositionCounterLookup", true);
+    tile = reader.lookupTileForPlane(0, 2, 3, 0, 0, 999);
+    assertNotNull(tile);
+    assertEquals(20, tile.offset);
+  }
+
+  @Test
+  public void testStoredFocusCountHandlesNullCount() {
+    // HIER_1_COUNT is absent; should return 1, not throw NumberFormatException
+    IniTable hierarchy = new IniTable();
+    hierarchy.put("HIER_COUNT", "2");
+    hierarchy.put("HIER_0_NAME", "Slide zoom level");
+    hierarchy.put("HIER_1_NAME", "Microscope focus level");
+
+    MiraxReader reader = new MiraxReader();
+    assertEquals(1, reader.getStoredFocusCount(hierarchy));
+  }
+
+  @Test
+  public void testFocusStepMicrometersUsesZStackLevelsOnly() {
+    IniTable hierarchy = new IniTable();
+    hierarchy.put("HIER_COUNT", "3");
+    hierarchy.put("HIER_0_NAME", "Slide zoom level");
+    hierarchy.put("HIER_1_NAME", "Slide filter level");
+    hierarchy.put("HIER_2_NAME", "Microscope focus level");
+    hierarchy.put("HIER_2_COUNT", "4");
+    hierarchy.put("HIER_2_VAL_0", "ExtFocusLevel");
+    hierarchy.put("HIER_2_VAL_0_SECTION", "LAYER_2_LEVEL_0_SECTION");
+    hierarchy.put("HIER_2_VAL_1", "ZStackLevel_(-1)");
+    hierarchy.put("HIER_2_VAL_1_SECTION", "LAYER_2_LEVEL_1_SECTION");
+    hierarchy.put("HIER_2_VAL_2", "ZStackLevel_(0)");
+    hierarchy.put("HIER_2_VAL_2_SECTION", "LAYER_2_LEVEL_2_SECTION");
+    hierarchy.put("HIER_2_VAL_3", "ZStackLevel_(+1)");
+    hierarchy.put("HIER_2_VAL_3_SECTION", "LAYER_2_LEVEL_3_SECTION");
+
+    IniList data = new IniList();
+    IniTable ext = new IniTable();
+    ext.put(IniTable.HEADER_KEY, "LAYER_2_LEVEL_0_SECTION");
+    ext.put("OFFSET_IN_MICROMETERS", "0");
+    data.add(ext);
+    IniTable z1 = new IniTable();
+    z1.put(IniTable.HEADER_KEY, "LAYER_2_LEVEL_1_SECTION");
+    z1.put("OFFSET_IN_MICROMETERS", "-2");
+    data.add(z1);
+    IniTable z2 = new IniTable();
+    z2.put(IniTable.HEADER_KEY, "LAYER_2_LEVEL_2_SECTION");
+    z2.put("OFFSET_IN_MICROMETERS", "0");
+    data.add(z2);
+    IniTable z3 = new IniTable();
+    z3.put(IniTable.HEADER_KEY, "LAYER_2_LEVEL_3_SECTION");
+    z3.put("OFFSET_IN_MICROMETERS", "2");
+    data.add(z3);
+
+    MiraxReader reader = new MiraxReader();
+    assertEquals(2.0, reader.getFocusStepMicrometers(hierarchy, data));
+  }
+
+  @Test
+  public void testFocusStepMicrometersDefaultsToNullWithoutStack() {
+    IniTable hierarchy = new IniTable();
+    hierarchy.put("HIER_COUNT", "2");
+    hierarchy.put("HIER_0_NAME", "Slide zoom level");
+    hierarchy.put("HIER_1_NAME", "Slide filter level");
+
+    MiraxReader reader = new MiraxReader();
+    assertNull(reader.getFocusStepMicrometers(hierarchy, new IniList()));
+  }
+
+  @Test
+  public void testParseFocusBlocksParsesSingleChannelGroup() throws Exception {
+    IniTable hierarchy = new IniTable();
+    hierarchy.put("HIER_COUNT", "3");
+    hierarchy.put("HIER_0_NAME", "Slide zoom level");
+    hierarchy.put("HIER_1_NAME", "Slide filter level");
+    hierarchy.put("HIER_1_COUNT", "3");
+    hierarchy.put("HIER_2_NAME", "Microscope focus level");
+    hierarchy.put("HIER_2_COUNT", "2");
+    hierarchy.put("HIER_2_VAL_0", "ZStackLevel_(-1)");
+    hierarchy.put("HIER_2_VAL_1", "ZStackLevel_(0)");
+
+    MiraxReader reader = new MiraxReader();
+    setField(reader, "fluorescence", true);
+    setField(reader, "storedFocusLevels", 2);
+    setField(reader, "pyramidDepth", 1);
+    setField(reader, "offsets", new java.util.TreeMap<>());
+
+    byte[] bytes = createSingleGroupFocusBlockIndex();
+    try (RandomAccessInputStream indexData =
+      new RandomAccessInputStream(new ByteArrayHandle(bytes)))
+    {
+      indexData.order(true);
+      Method method = MiraxReader.class.getDeclaredMethod(
+        "parseFocusBlocks", RandomAccessInputStream.class, long[].class,
+        IniTable.class);
+      method.setAccessible(true);
+
+      boolean parsed = (Boolean) method.invoke(
+        reader, indexData, new long[] {8L}, hierarchy);
+      assertTrue(parsed);
+    }
+
+    SortedMap<?, ?> offsets =
+      (SortedMap<?, ?>) getField(reader, "offsets");
+    assertEquals(2, offsets.size());
+
+    List<?> firstPlane = (List<?>) offsets.get(reader.new TilePointer(0, 10));
+    assertNotNull(firstPlane);
+    assertEquals(1, firstPlane.size());
+    MiraxReader.TilePointer firstPointer =
+      (MiraxReader.TilePointer) firstPlane.get(0);
+    assertEquals(0, firstPointer.sourceValue);
+    assertEquals(100, firstPointer.offset);
+
+    List<?> secondPlane = (List<?>) offsets.get(reader.new TilePointer(0, 20));
+    assertNotNull(secondPlane);
+    assertEquals(1, secondPlane.size());
+    MiraxReader.TilePointer secondPointer =
+      (MiraxReader.TilePointer) secondPlane.get(0);
+    assertEquals(1, secondPointer.sourceValue);
+    assertEquals(200, secondPointer.offset);
+  }
+
+  @Test
+  public void testParseFocusBlocksSkipsInterleavedNonZLevels()
+    throws Exception
+  {
+    IniTable hierarchy = new IniTable();
+    hierarchy.put("HIER_COUNT", "3");
+    hierarchy.put("HIER_0_NAME", "Slide zoom level");
+    hierarchy.put("HIER_1_NAME", "Slide filter level");
+    hierarchy.put("HIER_1_COUNT", "3");
+    hierarchy.put("HIER_2_NAME", "Microscope focus level");
+    hierarchy.put("HIER_2_COUNT", "4");
+    hierarchy.put("HIER_2_VAL_0", "ExtFocusLevel");
+    hierarchy.put("HIER_2_VAL_1", "ZStackLevel_(-1)");
+    hierarchy.put("HIER_2_VAL_2", "DerivedFocusLevel");
+    hierarchy.put("HIER_2_VAL_3", "ZStackLevel_(0)");
+
+    MiraxReader reader = new MiraxReader();
+    setField(reader, "fluorescence", true);
+    setField(reader, "storedFocusLevels", 4);
+    setField(reader, "pyramidDepth", 1);
+    setField(reader, "offsets", new java.util.TreeMap<>());
+
+    byte[] bytes = createInterleavedFocusBlockIndex();
+    try (RandomAccessInputStream indexData =
+      new RandomAccessInputStream(new ByteArrayHandle(bytes)))
+    {
+      indexData.order(true);
+      Method method = MiraxReader.class.getDeclaredMethod(
+        "parseFocusBlocks", RandomAccessInputStream.class, long[].class,
+        IniTable.class);
+      method.setAccessible(true);
+
+      boolean parsed = (Boolean) method.invoke(
+        reader, indexData, new long[] {8L}, hierarchy);
+      assertTrue(parsed);
+    }
+
+    @SuppressWarnings("unchecked")
+    SortedMap<MiraxReader.TilePointer, List<MiraxReader.TilePointer>> offsets =
+      (SortedMap<MiraxReader.TilePointer, List<MiraxReader.TilePointer>>) getField(
+        reader, "offsets");
+    assertEquals(2, offsets.size());
+
+    List<MiraxReader.TilePointer> firstPlane =
+      offsets.get(reader.new TilePointer(0, 10));
+    assertNotNull(firstPlane);
+    assertEquals(0, firstPlane.get(0).sourceValue);
+    assertEquals(100, firstPlane.get(0).offset);
+
+    List<MiraxReader.TilePointer> secondPlane =
+      offsets.get(reader.new TilePointer(0, 20));
+    assertNotNull(secondPlane);
+    assertEquals(1, secondPlane.get(0).sourceValue);
+    assertEquals(200, secondPlane.get(0).offset);
+
+    assertNull(offsets.get(reader.new TilePointer(0, 15)));
+  }
+
+  @Test
+  public void testParseClassicRootOffsetsSkipsNonZeroResolutions()
+    throws Exception
+  {
+    MiraxReader reader = new MiraxReader();
+    setField(reader, "pyramidDepth", 2);
+    setField(reader, "offsets", new TreeMap<>());
+
+    byte[] bytes = createClassicRootIndex();
+    try (RandomAccessInputStream indexData =
+      new RandomAccessInputStream(new ByteArrayHandle(bytes)))
+    {
+      indexData.order(true);
+      Method method = MiraxReader.class.getDeclaredMethod(
+        "parseClassicRootOffsets", RandomAccessInputStream.class, long.class,
+        int.class);
+      method.setAccessible(true);
+      method.invoke(reader, indexData, 8L, 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    SortedMap<MiraxReader.TilePointer, List<MiraxReader.TilePointer>> offsets =
+      (SortedMap<MiraxReader.TilePointer, List<MiraxReader.TilePointer>>) getField(
+        reader, "offsets");
+    assertEquals(1, offsets.size());
+
+    List<MiraxReader.TilePointer> tiles =
+      offsets.get(reader.new TilePointer(0, 10));
+    assertNotNull(tiles);
+    assertEquals(1, tiles.size());
+    assertEquals(100, tiles.get(0).offset);
+    assertEquals(0, tiles.get(0).sourceValue);
+
+    assertNull(offsets.get(reader.new TilePointer(1, 20)));
+  }
+
+  @Test
+  public void testTilePointerCompareToReturnsZeroForEqualPointers() {
+    MiraxReader reader = new MiraxReader();
+
+    MiraxReader.TilePointer left =
+      reader.new TilePointer(0, 1, 100, 10, 5, 2);
+    MiraxReader.TilePointer right =
+      reader.new TilePointer(0, 1, 100, 10, 5, 2);
+
+    assertEquals(0, left.compareTo(right));
+    assertEquals(0, right.compareTo(left));
+    assertEquals(left, right);
+  }
+
+  @Test
+  public void testTilePointerCompareToOrdersByLength() {
+    MiraxReader reader = new MiraxReader();
+
+    MiraxReader.TilePointer shorter =
+      reader.new TilePointer(0, 1, 100, 10, 5, 2);
+    MiraxReader.TilePointer longer =
+      reader.new TilePointer(0, 1, 100, 10, 6, 2);
+
+    assertTrue(shorter.compareTo(longer) < 0);
+    assertTrue(longer.compareTo(shorter) > 0);
+  }
+
+  private static void setField(Object target, String fieldName, Object value)
+    throws Exception
+  {
+    Field field = MiraxReader.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Object getField(Object target, String fieldName)
+    throws Exception
+  {
+    Field field = MiraxReader.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  private static void setSuperclassField(Object target, String fieldName,
+    Object value) throws Exception
+  {
+    Class<?> type = target.getClass().getSuperclass();
+    while (type != null) {
+      try {
+        Field field = type.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+        return;
+      }
+      catch (NoSuchFieldException e) {
+        type = type.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(fieldName);
+  }
+
+  private static byte[] createSingleGroupFocusBlockIndex() {
+    ByteBuffer buffer = ByteBuffer.allocate(128).order(ByteOrder.LITTLE_ENDIAN);
+
+    buffer.position(8);
+    buffer.putInt(0);
+    buffer.putInt(24);
+    buffer.putInt(0);
+    buffer.putInt(52);
+
+    buffer.position(24);
+    buffer.putInt(1);
+    buffer.putInt(0);
+    buffer.putInt(10);
+    buffer.putInt(100);
+    buffer.putInt(11);
+    buffer.putInt(2);
+    buffer.putInt(11);
+
+    buffer.position(52);
+    buffer.putInt(1);
+    buffer.putInt(0);
+    buffer.putInt(20);
+    buffer.putInt(200);
+    buffer.putInt(22);
+    buffer.putInt(3);
+    buffer.putInt(21);
+
+    return buffer.array();
+  }
+
+  private static byte[] createClassicRootIndex() {
+    ByteBuffer buffer = ByteBuffer.allocate(128).order(ByteOrder.LITTLE_ENDIAN);
+
+    buffer.position(8);
+    buffer.putInt(32);
+    buffer.putInt(64);
+
+    buffer.position(32);
+    buffer.putInt(0);
+    buffer.putInt(48);
+
+    buffer.position(48);
+    buffer.putInt(1);
+    buffer.putInt(0);
+    buffer.putInt(10);
+    buffer.putInt(100);
+    buffer.putInt(5);
+    buffer.putInt(1);
+    buffer.putInt(11);
+
+    buffer.position(64);
+    buffer.putInt(0);
+    buffer.putInt(80);
+
+    buffer.position(80);
+    buffer.putInt(1);
+    buffer.putInt(0);
+    buffer.putInt(20);
+    buffer.putInt(200);
+    buffer.putInt(5);
+    buffer.putInt(2);
+    buffer.putInt(21);
+
+    return buffer.array();
+  }
+
+  private static byte[] createInterleavedFocusBlockIndex() {
+    ByteBuffer buffer = ByteBuffer.allocate(192).order(ByteOrder.LITTLE_ENDIAN);
+
+    buffer.position(8);
+    buffer.putInt(0);
+    buffer.putInt(40);
+    buffer.putInt(0);
+    buffer.putInt(72);
+    buffer.putInt(0);
+    buffer.putInt(104);
+    buffer.putInt(0);
+    buffer.putInt(136);
+
+    buffer.position(40);
+    buffer.putInt(1);
+    buffer.putInt(0);
+    buffer.putInt(999);
+    buffer.putInt(900);
+    buffer.putInt(11);
+    buffer.putInt(1);
+    buffer.putInt(1000);
+
+    buffer.position(72);
+    buffer.putInt(1);
+    buffer.putInt(0);
+    buffer.putInt(10);
+    buffer.putInt(100);
+    buffer.putInt(11);
+    buffer.putInt(1);
+    buffer.putInt(11);
+
+    buffer.position(104);
+    buffer.putInt(1);
+    buffer.putInt(0);
+    buffer.putInt(888);
+    buffer.putInt(800);
+    buffer.putInt(22);
+    buffer.putInt(1);
+    buffer.putInt(889);
+
+    buffer.position(136);
+    buffer.putInt(1);
+    buffer.putInt(0);
+    buffer.putInt(20);
+    buffer.putInt(200);
+    buffer.putInt(22);
+    buffer.putInt(1);
+    buffer.putInt(21);
+
+    return buffer.array();
+  }
+}


### PR DESCRIPTION
## Summary

This PR fixes [#42](https://github.com/glencoesoftware/bioformats2raw/issues/42) by adding MRXS fluorescence Z-stack support in `MiraxReader`.

It:
- exposes real Z planes as `SizeZ > 1`
- excludes `ExtFocusLevel` from the physical Z axis
- derives `PhysicalSizeZ` from `OFFSET_IN_MICROMETERS`
- reads fluorescence focus-page blocks from `Index.dat`
- preserves the classic path for older/non-stack MRXS files

## Validation

The Z-stack behavior was validated with the sample from [#42](https://github.com/glencoesoftware/bioformats2raw/issues/42), and also with additional private MRXS Z-stack data.

I also regenerated a full OME-Zarr for the issue sample and checked it visually:
- main Z-stack opened correctly
- label image opened correctly
- fourth channel opened correctly

For regression coverage on non-Z MRXS files, I tested with:
- [OpenSlide Mirax test data](https://openslide.cs.cmu.edu/download/openslide-testdata/Mirax/)
- [10.5281/zenodo.10966338](https://doi.org/10.5281/zenodo.10966338) (excluding the `BMP24` sample, since BMP24 is not supported on `master` either)
- [10.5281/zenodo.16962727](https://doi.org/10.5281/zenodo.16962727)
- additional private brightfield MRXS data

Focused `MiraxReader` unit tests cover the new parsing and the classic fallback behavior.

I have not yet validated this branch on JPEG-XR-compressed MRXS data.

## Notes

This change was developed with assistance from Codex using GPT-5.4.

One small follow-up left out of this PR to keep the diff focused: `indexData` in `MiraxReader.initFile()` still uses explicit close logic rather than try-with-resources.
