### PR TITLE
feat(mirax): store excitation and emission wavelength metadata

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/MiraxReader.java
@@ -1075,6 +1075,8 @@ public class MiraxReader extends FormatReader {
         String blue = channelTable.get("COLOR_B");
         String exposure = channelTable.get("EXPOSURE_TIME");
         String gain = channelTable.get("DIGITALGAIN");
+        String excitation = channelTable.get("EXCITATION_WAVELENGTH");
+        String emission = channelTable.get("EMISSION_WAVELENGTH");
         boolean useRed =
           Boolean.valueOf(channelTable.get("USE_RED_CHANNEL").toLowerCase());
         boolean useGreen =
@@ -1090,6 +1092,31 @@ public class MiraxReader extends FormatReader {
 
         if (name != null && !name.equals("Default")) {
           store.setChannelName(name, 0, c);
+        }
+        if (excitation != null) {
+          try {
+            double wavelength = Double.parseDouble(excitation);
+            if (wavelength > 0) {
+              store.setChannelExcitationWavelength(
+                FormatTools.getExcitationWavelength(wavelength), 0, c);
+            }
+          }
+          catch (NumberFormatException e) {
+            LOGGER.debug(
+              "Could not parse excitation wavelength {}", excitation);
+          }
+        }
+        if (emission != null) {
+          try {
+            double wavelength = Double.parseDouble(emission);
+            if (wavelength > 0) {
+              store.setChannelEmissionWavelength(
+                FormatTools.getEmissionWavelength(wavelength), 0, c);
+            }
+          }
+          catch (NumberFormatException e) {
+            LOGGER.debug("Could not parse emission wavelength {}", emission);
+          }
         }
         if (red != null && green != null && blue != null) {
           int r = 0;


### PR DESCRIPTION
This PR adds MRXS channel excitation and emission wavelength metadata.

I tested with:
- [OpenSlide Mirax test data](https://openslide.cs.cmu.edu/download/openslide-testdata/Mirax/)
- [10.5281/zenodo.16962727](https://doi.org/10.5281/zenodo.16962727)
- private brightfield MRXS data


I also checked the generated OME-XML with `xmlvalid`:
```
No validation errors found.
```

NB:
- older MRXS slide versions may not include these fields at all
- newer brightfield MRXS data include these fields but with placeholder `0` values