### PR TITLE
Fix `scale` recorded with `--use-existing-resolutions` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Run the conversion:
     bioformats2raw /path/to/file.svs /path/to/zarr-pyramid
 
 By default, the resolutions will be set so that the smallest resolution is no greater than 256x256.
+A scaling factor of 2 is used between consecutive resolutions.
 The target of the smallest resolution can be configured with `--target-min-size` e.g. to ensure
 that the smallest resolution is no greater than 128x128
 
@@ -411,8 +412,11 @@ conversions, but if they are needed for troubleshooting then the `--keep-memo-fi
 need to be created, `--keep-memo-files` will still result in no `.*.bfmemo` files at the end of conversion. This is particularly common
 for small datasets that can be read very quickly.
 
+Downsampling options
+====================
+
 Downsampling type
-=================
+-----------------
 
 By default, pyramid resolutions are generated using a [very simple downsampling algorithm](https://github.com/ome/ome-common-java/blob/master/src/main/java/loci/common/image/SimpleImageScaler.java).
 For some input data types, this may not be ideal. The `--downsample-type` option can be used to specify an alternative algorithm.
@@ -421,6 +425,17 @@ No additional downsampling algorithms are directly implemented in bioformats2raw
 
 If the minimum system requirements (see above) are not met, or the input data type is int8 or int32 (see https://github.com/glencoesoftware/bioformats2raw/pull/199),
 then any value of `--downsample-type` other than the default is expected to throw an exception.
+
+Converting an existing pyramid
+------------------------------
+
+Some input file formats will already contain pyramid resolutions. By default, all resolutions other than the largest will be ignored, and the pyramid will be recalculated.
+To preserve the existing pyramid instead of recalculating, use the `--use-existing-resolutions` option.
+
+If `--use-existing-resolutions` is specified for an image with no existing pyramid, then a pyramid will still be calculated according to the image dimensions.
+
+Note that an existing pyramid may have a scaling factor other than 2, may have inconsistent scaling factors between different resolutions in the same pyramid,
+and may have a smallest resolution that is larger than expected. This can lead to sub-optimal performance when viewing, particularly when viewing data imported into OMERO.
 
 Additional readers
 ==================

--- a/README.md
+++ b/README.md
@@ -434,8 +434,8 @@ To preserve the existing pyramid instead of recalculating, use the `--use-existi
 
 If `--use-existing-resolutions` is specified for an image with no existing pyramid, then a pyramid will still be calculated according to the image dimensions.
 
-Note that an existing pyramid may have a scaling factor other than 2, may have inconsistent scaling factors between different resolutions in the same pyramid,
-and may have a smallest resolution that is larger than expected. This can lead to sub-optimal performance when viewing, particularly when viewing data imported into OMERO.
+Note that an existing pyramid may not be ideal for viewing. It may have a scaling factor other than 2, use different scaling factors at different resolution levels,
+or contain fewer resolutions than are ideal. This can lead to sub-optimal viewing performance, especially for data imported into OMERO.
 
 Additional readers
 ==================

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -2897,12 +2897,35 @@ public class Converter implements Callable<Integer> {
     IMetadata meta = null;
     List<Axis> activeAxes = null;
 
+    List<Double> resolutionScalesX = new ArrayList<Double>();
+    List<Double> resolutionScalesY = new ArrayList<Double>();
     try {
       v = readers.take();
       meta = (IMetadata) v.getMetadataStore();
+      v.setResolution(0);
 
-      activeAxes = getDimensions(v, v.getSizeX(), v.getSizeY(),
-        v.getSizeZ(), 1, 1, 1);
+      int baseX = v.getSizeX();
+      int baseY = v.getSizeY();
+      activeAxes = getDimensions(v, baseX, baseY, v.getSizeZ(), 1, 1, 1);
+
+      for (int r=0; r<resolutions; r++) {
+        if (v.getResolutionCount() > 1 && reuseExistingResolutions) {
+          v.setResolution(r);
+          if (r == 0) {
+            resolutionScalesX.add(1.0);
+            resolutionScalesY.add(1.0);
+          }
+          else {
+            resolutionScalesX.add((double) baseX / v.getSizeX());
+            resolutionScalesY.add((double) baseY / v.getSizeY());
+          }
+        }
+        else {
+          double scale = Math.pow(PYRAMID_SCALE, r);
+          resolutionScalesX.add(scale);
+          resolutionScalesY.add(scale);
+        }
+      }
     }
     finally {
       readers.put(v);
@@ -2929,7 +2952,6 @@ public class Converter implements Callable<Integer> {
       Map<String, Object> scale = new HashMap<String, Object>();
       scale.put("type", "scale");
       List<Double> axisValues = new ArrayList<Double>();
-      double resolutionScale = Math.pow(PYRAMID_SCALE, r);
       for (int i=0; i<activeAxes.size(); i++) {
         String axisChar =
           String.valueOf(activeAxes.get(i).getType()).toLowerCase();
@@ -2940,19 +2962,26 @@ public class Converter implements Callable<Integer> {
           // use it directly for dimensions that aren't scaled (Z and T)
           // increase it according to the resolution number for dimensions that
           // are scaled (X and Y)
-          if (axisChar.equals("x") || axisChar.equals("y")) {
-            axisValues.add(axisScale.value().doubleValue() * resolutionScale);
+          double as = axisScale.value().doubleValue();
+          if (axisChar.equals("x")) {
+            axisValues.add(as * resolutionScalesX.get(r));
+          }
+          else if (axisChar.equals("y")) {
+            axisValues.add(as * resolutionScalesY.get(r));
           }
           else {
-            axisValues.add(axisScale.value().doubleValue());
+            axisValues.add(as);
           }
         }
         else {
           // if physical dimension information is not defined,
           // store the scale factor for the dimension in the current resolution,
           // i.e. 1.0 for everything other than X and Y
-          if (axisChar.equals("x") || axisChar.equals("y")) {
-            axisValues.add(resolutionScale);
+          if (axisChar.equals("x")) {
+            axisValues.add(resolutionScalesX.get(r));
+          }
+          else if (axisChar.equals("y")) {
+            axisValues.add(resolutionScalesY.get(r));
           }
           else {
             axisValues.add(1.0);

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrTest.java
@@ -1874,13 +1874,34 @@ public class ZarrTest extends AbstractZarrTest {
     List<Map<String, Object>> datasets =
               (List<Map<String, Object>>) multiscale.get("datasets");
     assertEquals(resolutionCount, datasets.size());
+
+    List<Map<String, Object>> axes =
+      (List<Map<String, Object>>) multiscale.get("axes");
+    checkAxes(axes, "TCZYX", null);
+
     for (int i = 0; i < resolutionCount; i++) {
-      String path = (String) datasets.get(i).get("path");
+      Map<String, Object> dataset = datasets.get(i);
+      String path = (String) dataset.get("path");
+      assertEquals(String.valueOf(i), path);
       Array series = Array.open(store.resolve("0", path));
       assertArrayEquals(
         new long[] {1, 1, 1, sizeY, sizeX}, series.metadata().shape);
       sizeY /= resolutionScale;
       sizeX /= resolutionScale;
+
+      List<Map<String, Object>> transforms =
+        (List<Map<String, Object>>) dataset.get("coordinateTransformations");
+      assertEquals(1, transforms.size());
+      Map<String, Object> scale = transforms.get(0);
+      assertEquals("scale", scale.get("type"));
+      List<Double> axisValues = (List<Double>) scale.get("scale");
+
+      assertEquals(5, axisValues.size());
+      double factor = Math.pow(resolutionScale, i);
+      // X and Y are the only dimensions that are downsampled,
+      // so the TCZ physical scales remain the same across all resolutions
+      assertEquals(axisValues, Arrays.asList(new Double[] {
+        1.0, 1.0, 1.0, factor, factor}));
     }
   }
 


### PR DESCRIPTION
Fixes #320.

This also adds a basic test to ensure that the scale is captured correctly. I tested with a couple of SVS files, including 77917.svs as described in #320, but it would be good to pick a couple of other files that contain pyramids with a downsample factor other than 2 to verify the behavior with and without `--use-existing-resolutions`.