### PR TITLE
Upgrade to zarr-java 0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Supported options for `blosc` are:
 * `clevel=<level>`, where the default is `clevel=5`. Valid values are integers from 0 to 9 inclusive, where 0 generally
   indicates no compression and 9 generally indicates most compression.
 * `blocksize=<blocksize>`, where the default is `blocksize=0`.
-* `shuffle=<shuffle type>`, where the default is `shuffle=byteshuffle`. Valid values are `noshuffle`, `shuffle`/`byteshuffle`, and `bitshuffle`.
+* `shuffle=<shuffle type>`, where the default is `shuffle=shuffle`. Valid values are `noshuffle`, `shuffle`, and `bitshuffle`.
 
 See also the blosc codec definition in the [Zarr v3 specification](https://zarr-specs.readthedocs.io/en/latest/v3/codecs/blosc/index.html#configuration-parameters).
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation 'ome:formats-gpl:8.5.0'
     implementation 'info.picocli:picocli:4.7.5'
     implementation 'com.univocity:univocity-parsers:2.8.4'
-    implementation 'dev.zarr:zarr-java:0.1.0'
+    implementation 'dev.zarr:zarr-java:0.1.3'
     // implementation 'org.carlspring.cloud.aws:s3fs-nio:1.0-SNAPSHOT'
     // implementation 'io.nextflow:nxf-s3fs:1.1.0'
     implementation 'org.lasersonlab:s3fs:2.2.3'

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -2561,7 +2561,7 @@ public class Converter implements Callable<Integer> {
           int blocksize = Integer.parseInt(
             compressionProperties.getOrDefault("blocksize", "0").toString());
           String shuffle = compressionProperties.getOrDefault(
-            "shuffle", "byteshuffle").toString();
+            "shuffle", "shuffle").toString();
           builder =
             builder.withBloscCompressor(cname, shuffle, clevel, blocksize);
         }
@@ -3491,7 +3491,7 @@ public class Converter implements Callable<Integer> {
       int blocksize = Integer.parseInt(
         compressionProperties.getOrDefault("blocksize", "0").toString());
       String shuffle = compressionProperties.getOrDefault(
-        "shuffle", "byteshuffle").toString();
+        "shuffle", "shuffle").toString();
 
       return builder.withBlosc(cname, shuffle, clevel, blocksize);
     }


### PR DESCRIPTION
Splitting zarr-java upgrade out of #322, since it can be considered separately (as discussed briefly with @sbesson).