### PR TITLE
Improve converter and cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,29 @@ You can configure logging by editing the provided `logback.xml` or by specifying
     JAVA_OPTS="-Dlogback.configurationFile=/path/to/external/logback.xml" \
     bioformats2raw ...
 
-Alternatively you can use the `--debug` flag, optionally writing the stdout to a file:
+Alternatively you can use the `--debug` flag, optionally writing the log output to a file:
 
-    bioformats2raw /path/to/file.mrxs /path/to/zarr-pyramid --debug > bf2raw.log
+    bioformats2raw /path/to/file.mrxs /path/to/zarr-pyramid --debug 2> bf2raw.log
 
 The `--log-level` option takes an [slf4j logging level](https://www.slf4j.org/faq.html#fatal) for additional simple logging configuration.
 `--log-level DEBUG` is equivalent to `--debug`. For even more verbose logging:
 
     bioformats2raw /path/to/file.mrxs /path/to/zarr-pyramid --log-level TRACE
+
+Command output and exit status
+==============================
+
+Help and version information are written to standard output. Logging,
+progress bars, warnings, and errors are written to standard error. A successful
+conversion does not otherwise write to standard output.
+
+Routine errors are concise. Use `--debug` or `--log-level DEBUG` to include a
+Java stack trace for troubleshooting.
+
+If conversion fails or is interrupted after writing starts, the output is kept
+and may be incomplete. When `--overwrite` is used, input is checked before the
+existing local output is removed. Each old path is deleted with error checking,
+but a deletion failure can still leave the existing output partially removed.
 
 Eclipse Configuration
 =====================

--- a/src/dist/lib/config/logback.xml
+++ b/src/dist/lib/config/logback.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="false">
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
     <encoder>
       <pattern>%date [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="info">
-    <appender-ref ref="STDOUT" />
+    <appender-ref ref="STDERR" />
   </root>
 </configuration>

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1691,53 +1691,56 @@ public class Converter implements Callable<Integer> {
     // Now with our found type instantiate our queue of readers for use
     // during conversion
     boolean savedMemoFile = false;
-    for (int i=0; i < maxWorkers; i++) {
-      IFormatReader reader;
-      Memoizer memoizer;
-      try {
-        reader = (IFormatReader) readerClass.getConstructor().newInstance();
-        if (fillValue != null) {
-          reader.setFillColor(fillValue.byteValue());
+    List<IFormatReader> initializedReaders =
+      new ArrayList<IFormatReader>();
+    try {
+      for (int i=0; i < maxWorkers; i++) {
+        IFormatReader reader;
+        Memoizer memoizer;
+        try {
+          reader = (IFormatReader) readerClass.getConstructor().newInstance();
+          if (fillValue != null) {
+            reader.setFillColor(fillValue.byteValue());
+          }
+          memoizer = createMemoizer(reader);
         }
-        memoizer = createMemoizer(reader);
-      }
-      catch (Exception e) {
-        LOGGER.error("Failed to instantiate reader: {}", readerClass, e);
-        return;
-      }
+        catch (Exception e) {
+          throw new FormatException(
+            "failed to instantiate reader " + readerClass.getName(), e);
+        }
 
-      if (readerOptions.size() > 0) {
-        DynamicMetadataOptions options = new DynamicMetadataOptions();
-        for (String option : readerOptions) {
-          String[] pair = option.split("=");
-          if (pair.length == 2) {
+        if (readerOptions.size() > 0) {
+          DynamicMetadataOptions options = new DynamicMetadataOptions();
+          for (String option : readerOptions) {
+            String[] pair = option.split("=", 2);
             options.set(pair[0], pair[1]);
           }
+          memoizer.setMetadataOptions(options);
         }
-        memoizer.setMetadataOptions(options);
+
+        memoizer.setOriginalMetadataPopulated(!noOMEMeta && originalMetadata);
+        memoizer.setFlattenedResolutions(false);
+        memoizer.setMetadataFiltered(true);
+        memoizer.setMetadataStore(createMetadata());
+        ChannelSeparator separator = new ChannelSeparator(memoizer);
+        initializedReaders.add(separator);
+        separator.setId(inputPath.toString());
+        separator.setResolution(0);
+        if (reader instanceof MiraxReader) {
+          ((MiraxReader) reader).setTileCache(tileCache);
+        }
+        if (omeroMetadata) {
+          IFormatReader minMaxReader = new MinMaxCalculator(separator);
+          initializedReaders.set(initializedReaders.size() - 1, minMaxReader);
+          readers.add(minMaxReader);
+        }
+        else {
+          readers.add(separator);
+        }
+        savedMemoFile = savedMemoFile || memoizer.isSavedToMemo();
       }
 
-      memoizer.setOriginalMetadataPopulated(!noOMEMeta && originalMetadata);
-      memoizer.setFlattenedResolutions(false);
-      memoizer.setMetadataFiltered(true);
-      memoizer.setMetadataStore(createMetadata());
-      ChannelSeparator separator = new ChannelSeparator(memoizer);
-      separator.setId(inputPath.toString());
-      separator.setResolution(0);
-      if (reader instanceof MiraxReader) {
-        ((MiraxReader) reader).setTileCache(tileCache);
-      }
-      if (omeroMetadata) {
-        readers.add(new MinMaxCalculator(separator));
-      }
-      else {
-        readers.add(separator);
-      }
-      savedMemoFile = savedMemoFile || memoizer.isSavedToMemo();
-    }
-
-    // Finally, perform conversion on all series
-    try {
+      // Finally, perform conversion on all series
       IFormatReader v = readers.take();
       IMetadata meta = null;
       try {
@@ -1821,8 +1824,7 @@ public class Converter implements Callable<Integer> {
         }
       }
       catch (ServiceException se) {
-        LOGGER.error("Could not retrieve OME-XML", se);
-        return;
+        throw new FormatException("could not retrieve OME-XML", se);
       }
       finally {
         readers.put(v);
@@ -1857,10 +1859,8 @@ public class Converter implements Callable<Integer> {
         try {
           write(index);
         }
-        catch (Throwable t) {
-          LOGGER.error("Error while writing series {}", index, t);
-          unwrapException(t);
-          return;
+        catch (Exception e) {
+          unwrapException(e);
         }
       }
 
@@ -1871,23 +1871,42 @@ public class Converter implements Callable<Integer> {
     finally {
       // Shut down first, tasks may still be running
       executor.shutdown();
-      executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
-      readers.forEach((v) -> {
+      InterruptedException interrupted = null;
+      try {
+        executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+      }
+      catch (InterruptedException e) {
+        executor.shutdownNow();
+        interrupted = e;
+        try {
+          executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+        }
+        catch (InterruptedException shutdownInterrupted) {
+          interrupted.addSuppressed(shutdownInterrupted);
+        }
+      }
+      initializedReaders.forEach((v) -> {
         try {
           v.close();
         }
         catch (IOException e) {
-          LOGGER.error("Exception while closing reader", e);
+          LOGGER.warn("Exception while closing reader: {}", e.getMessage());
         }
       });
-    }
-
-    // delete the memo file if it was saved and it's not explicitly kept
-    // this should mean that memo files which existed before conversion
-    // started will not be deleted
-    if (savedMemoFile && !keepMemoFiles) {
-      File memoFile = createMemoizer(null).getMemoFile(inputPath.toString());
-      memoFile.delete();
+      // Only delete memo files that were created by this conversion.
+      if (savedMemoFile && !keepMemoFiles) {
+        File memoFile = createMemoizer(null).getMemoFile(inputPath.toString());
+        try {
+          Files.deleteIfExists(memoFile.toPath());
+        }
+        catch (IOException e) {
+          LOGGER.warn("Could not delete memo file {}: {}",
+            memoFile, e.getMessage());
+        }
+      }
+      if (interrupted != null) {
+        throw interrupted;
+      }
     }
   }
 
@@ -2869,7 +2888,7 @@ public class Converter implements Callable<Integer> {
                     }
                     catch (Throwable t) {
                       future.completeExceptionally(t);
-                      LOGGER.error(
+                      LOGGER.debug(
                         "Failure processing chunk; resolution={} plane={} " +
                         "xx={} yy={} zz={} width={} height={} depth={}",
                         resolution, plane, xx, yy, zz, width, height, depth, t);
@@ -3336,7 +3355,8 @@ public class Converter implements Callable<Integer> {
         readers.forEach((minmax) -> {
           try {
             if (!(minmax instanceof MinMaxCalculator)) {
-              LOGGER.error("Cannot set OMERO min/max data");
+              LOGGER.warn("Cannot set OMERO min/max data; using type range");
+              return;
             }
 
             MinMaxCalculator calc = (MinMaxCalculator) minmax;
@@ -3355,7 +3375,8 @@ public class Converter implements Callable<Integer> {
             }
           }
           catch (FormatException|IOException e) {
-            LOGGER.error("Cannot set OMERO min/max data", e);
+            LOGGER.warn("Cannot set OMERO min/max data; using type range: {}",
+              e.getMessage());
           }
         });
 
@@ -3451,7 +3472,7 @@ public class Converter implements Callable<Integer> {
         throw rt;
       }
       catch (Throwable t2) {
-        throw new RuntimeException(t);
+        throw new RuntimeException(t2);
       }
     }
     else if (t instanceof RuntimeException) {

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -1026,7 +1026,7 @@ public class Converter implements Callable<Integer> {
       names = "--target-min-size",
       description = "Specifies the desired size for the largest XY dimension " +
           "of the smallest resolution, when calculating the number " +
-          "of resolutions generate. If the target size cannot be matched " +
+          "of resolutions to generate. If the target size cannot be matched " +
           "exactly, the largest XY dimension of the smallest resolution " +
           "should be smaller than the target size.",
       defaultValue = "" + MIN_SIZE
@@ -1062,7 +1062,7 @@ public class Converter implements Callable<Integer> {
   @Option(
           names = "--dimension-order",
           description = "Override the input file dimension order in the " +
-                  "output file [DEPRECRATED, results in " +
+                  "output file [DEPRECATED, results in " +
                   "invalid OME-NGFF data] " +
                   "(${COMPLETION-CANDIDATES})",
           converter = DimensionOrderConverter.class,
@@ -1930,8 +1930,7 @@ public class Converter implements Callable<Integer> {
         ((dev.zarr.zarrjava.v3.Group) root).setAttributes(rootAttributes);
       }
       else {
-        dev.zarr.zarrjava.v2.Group root =
-          dev.zarr.zarrjava.v2.Group.create(store.resolve(), attributes);
+        dev.zarr.zarrjava.v2.Group.create(store.resolve(), attributes);
       }
     }
     if (!noOMEMeta) {
@@ -1965,8 +1964,7 @@ public class Converter implements Callable<Integer> {
       }
       else {
         omeAttributes.put("series", groups);
-        dev.zarr.zarrjava.v2.Group omeRoot =
-          dev.zarr.zarrjava.v2.Group.create(store.resolve("OME"),
+        dev.zarr.zarrjava.v2.Group.create(store.resolve("OME"),
           omeAttributes);
       }
     }
@@ -2250,7 +2248,6 @@ public class Converter implements Callable<Integer> {
     if (shardOffsets.containsKey(pathName) &&
       !isWholeShard(array, shape, offset))
     {
-      dev.zarr.zarrjava.v3.Array v3Array = (dev.zarr.zarrjava.v3.Array) array;
       int[] shardSizes = array.metadata().chunkShape();
       long[] shard = new long[shardSizes.length];
       for (int i=0; i<offset.length; i++) {
@@ -2432,7 +2429,6 @@ public class Converter implements Callable<Integer> {
       throws EnumerationException
   {
     ArrayList<Axis> axes = new ArrayList<Axis>();
-    int sizeZ = reader.getSizeZ();
     int sizeC = reader.getSizeC();
     int sizeT = reader.getSizeT();
     String o = new StringBuilder(
@@ -2811,7 +2807,7 @@ public class Converter implements Callable<Integer> {
         }
 
         final CodecBuilder builder = codecBuilder;
-        Array v3Array = dev.zarr.zarrjava.v3.Array.create(handle,
+        dev.zarr.zarrjava.v3.Array.create(handle,
           dev.zarr.zarrjava.v3.Array.metadataBuilder()
             .withDimensionNames(dimensionNames)
             .withShape(Utils.toLongArray(arrayShape))
@@ -3050,7 +3046,7 @@ public class Converter implements Callable<Integer> {
 
           String rowPath = index.getRowPath();
           String columnPath = index.getColumnPath();
-          Group rowGroup = createGroup(rowPath);
+          createGroup(rowPath);
           if (getV3()) {
             Group columnGroup = createGroup(rowPath, columnPath);
             Attributes omeAttrs = new Attributes();
@@ -3059,9 +3055,8 @@ public class Converter implements Callable<Integer> {
             ((dev.zarr.zarrjava.v3.Group) columnGroup).setAttributes(omeAttrs);
           }
           else {
-            dev.zarr.zarrjava.v2.Group columnGroup =
-              dev.zarr.zarrjava.v2.Group.create(
-                store.resolve(rowPath, columnPath),
+            dev.zarr.zarrjava.v2.Group.create(
+              store.resolve(rowPath, columnPath),
               columnAttrs);
           }
 
@@ -3446,8 +3441,7 @@ public class Converter implements Callable<Integer> {
       ((dev.zarr.zarrjava.v3.Group) seriesGroup).setAttributes(attributes);
     }
     else {
-      dev.zarr.zarrjava.v2.Group seriesGroup =
-        dev.zarr.zarrjava.v2.Group.create(
+      dev.zarr.zarrjava.v2.Group.create(
         store.resolve(seriesString), attributes);
     }
     LOGGER.debug("    finished writing subgroup attributes");
@@ -3846,10 +3840,6 @@ public class Converter implements Callable<Integer> {
 
   private Group openGroup(String... path) throws IOException, ZarrException {
     return Group.open(store.resolve(path));
-  }
-
-  private static Slf4JStopWatch stopWatch() {
-    return new Slf4JStopWatch(LOGGER, Slf4JStopWatch.DEBUG_LEVEL);
   }
 
   /**

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -22,7 +22,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IllegalFormatException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -174,7 +177,7 @@ public class Converter implements Callable<Integer> {
   private volatile boolean originalMetadata = true;
 
   private volatile SupportedVersions ngffVersion = SupportedVersions.NGFF_04;
-  private volatile boolean v3 = false;
+  private volatile boolean ngffVersionSet = false;
   private volatile FilesystemStore store = null;
 
   private volatile int maxWorkers;
@@ -301,6 +304,12 @@ public class Converter implements Callable<Integer> {
     defaultValue = Option.NULL_VALUE
   )
   public void setOutputOptions(Map<String, String> options) {
+    if (options != null && (options.containsKey(null) ||
+      options.containsValue(null)))
+    {
+      throw new InvalidConfigurationException(
+        "--output-options entries must use key=value syntax");
+    }
     outputOptions = options;
   }
 
@@ -324,7 +333,8 @@ public class Converter implements Callable<Integer> {
       pyramidResolutions = resolutions;
     }
     else {
-      LOGGER.warn("Ignoring invalid resolution count: {}", resolutions);
+      throw new InvalidConfigurationException(
+        "--resolutions must be greater than zero");
     }
   }
 
@@ -344,6 +354,10 @@ public class Converter implements Callable<Integer> {
   )
   public void setSeriesList(List<Integer> seriesToConvert) {
     if (seriesToConvert != null) {
+      if (seriesToConvert.stream().anyMatch((index) -> index < 0)) {
+        throw new InvalidConfigurationException(
+          "--series indexes must be zero or greater");
+      }
       seriesList = seriesToConvert;
     }
     else {
@@ -365,12 +379,8 @@ public class Converter implements Callable<Integer> {
     defaultValue = "1024"
   )
   public void setTileWidth(int width) {
-    if (width > 0) {
-      tileWidth = width;
-    }
-    else {
-      LOGGER.warn("Ignoring invalid tile width: {}", width);
-    }
+    requirePositive("--tile-width", width);
+    tileWidth = width;
   }
 
   /**
@@ -387,12 +397,8 @@ public class Converter implements Callable<Integer> {
     defaultValue = "1024"
   )
   public void setTileHeight(int height) {
-    if (height > 0) {
-      tileHeight = height;
-    }
-    else {
-      LOGGER.warn("Ignoring invalid tile height: {}", height);
-    }
+    requirePositive("--tile-height", height);
+    tileHeight = height;
   }
 
   /**
@@ -406,12 +412,8 @@ public class Converter implements Callable<Integer> {
     defaultValue = "1"
   )
   public void setChunkDepth(int depth) {
-    if (depth > 0) {
-      chunkDepth = depth;
-    }
-    else {
-      LOGGER.warn("Ignoring invalid chunk depth: {}", depth);
-    }
+    requirePositive("--chunk-depth", depth);
+    chunkDepth = depth;
   }
 
   /**
@@ -426,12 +428,8 @@ public class Converter implements Callable<Integer> {
     defaultValue = "1024"
   )
   public void setShardWidth(int width) {
-    if (width > 0) {
-      shardWidth = width;
-    }
-    else {
-      LOGGER.warn("Ignoring invalid shard width: {}", width);
-    }
+    requirePositive("--shard-width", width);
+    shardWidth = width;
   }
 
   /**
@@ -446,12 +444,8 @@ public class Converter implements Callable<Integer> {
     defaultValue = "1024"
   )
   public void setShardHeight(int height) {
-    if (height > 0) {
-      shardHeight = height;
-    }
-    else {
-      LOGGER.warn("Ignoring invalid shard height: {}", height);
-    }
+    requirePositive("--shard-height", height);
+    shardHeight = height;
   }
 
   /**
@@ -465,12 +459,8 @@ public class Converter implements Callable<Integer> {
     defaultValue = "1"
   )
   public void setShardDepth(int depth) {
-    if (depth > 0) {
-      shardDepth = depth;
-    }
-    else {
-      LOGGER.warn("Ignoring invalid shard depth: {}", depth);
-    }
+    requirePositive("--shard-depth", depth);
+    shardDepth = depth;
   }
 
   /**
@@ -503,7 +493,14 @@ public class Converter implements Callable<Integer> {
   )
   public void setLogLevel(String level) {
     if (level != null) {
-      logLevel = level;
+      String normalized = level.toUpperCase(Locale.ROOT);
+      List<String> levels = Arrays.asList(
+        "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "ALL");
+      if (!levels.contains(normalized)) {
+        throw new InvalidConfigurationException(
+          "--log-level must be one of " + String.join(", ", levels));
+      }
+      logLevel = normalized;
     }
   }
 
@@ -582,15 +579,13 @@ public class Converter implements Callable<Integer> {
     defaultValue = "4"
   )
   public void setMaxWorkers(int workers) {
+    requirePositive("--max-workers", workers);
     int availableProcessors = Runtime.getRuntime().availableProcessors();
     if (workers > availableProcessors) {
       maxWorkers = availableProcessors;
     }
-    else if (workers > 0) {
-      maxWorkers = workers;
-    }
     else {
-      LOGGER.warn("Ignoring invalid worker count: {}", workers);
+      maxWorkers = workers;
     }
   }
 
@@ -609,6 +604,10 @@ public class Converter implements Callable<Integer> {
     defaultValue = "64"
   )
   public void setMaxCachedTiles(int maxTiles) {
+    if (maxTiles < 0) {
+      throw new InvalidConfigurationException(
+        "--max-cached-tiles must be zero or greater");
+    }
     maxCachedTiles = maxTiles;
   }
 
@@ -641,6 +640,10 @@ public class Converter implements Callable<Integer> {
   )
   public void setCompressionProperties(Map<String, Object> properties) {
     if (properties != null) {
+      if (properties.containsKey(null) || properties.containsValue(null)) {
+        throw new InvalidConfigurationException(
+          "--compression-properties entries must use key=value syntax");
+      }
       compressionProperties = properties;
     }
     else {
@@ -672,6 +675,12 @@ public class Converter implements Callable<Integer> {
   )
   public void setExtraReaders(Class<?>[] extraReaderList) {
     if (extraReaderList != null) {
+      for (Class<?> reader : extraReaderList) {
+        if (reader == null || !IFormatReader.class.isAssignableFrom(reader)) {
+          throw new InvalidConfigurationException(
+            "--extra-readers classes must implement IFormatReader");
+        }
+      }
       extraReaders = extraReaderList;
     }
   }
@@ -710,7 +719,12 @@ public class Converter implements Callable<Integer> {
   public void setUnnested(boolean unnested) {
     nested = !unnested;
     if (!nested) {
+      if (ngffVersionSet && ngffVersion != SupportedVersions.NGFF_01) {
+        throw new InvalidConfigurationException(
+          "--no-nested is only compatible with --ngff-version 0.1");
+      }
       setNGFFVersion(SupportedVersions.NGFF_01);
+      ngffVersionSet = false;
     }
   }
 
@@ -748,9 +762,11 @@ public class Converter implements Callable<Integer> {
           defaultValue = "%d/%d"
   )
   public void setScaleFormat(String formatString) {
-    if (formatString != null) {
-      scaleFormatString = formatString;
+    if (formatString == null || formatString.isEmpty()) {
+      throw new InvalidConfigurationException(
+        "--scale-format-string must not be empty");
     }
+    scaleFormatString = formatString;
   }
 
   /**
@@ -780,16 +796,16 @@ public class Converter implements Callable<Integer> {
    */
   @Option(
           names = "--ngff-version",
-          description = "Write the specified NGFF version, if supported",
-          defaultValue = "0.4"
+          description = "Write the specified NGFF version, if supported " +
+            "(default: 0.4)"
   )
   public void setNGFFVersion(SupportedVersions version) {
     if (!getNested() && version != SupportedVersions.NGFF_01) {
-      LOGGER.warn("Cannot use unnested storage with version {}", version);
+      throw new InvalidConfigurationException(
+        "--no-nested is only compatible with --ngff-version 0.1");
     }
-    else {
-      ngffVersion = version;
-    }
+    ngffVersion = version;
+    ngffVersionSet = true;
   }
 
   /**
@@ -868,7 +884,8 @@ public class Converter implements Callable<Integer> {
       fillValue = tileFill;
     }
     else {
-      LOGGER.warn("Ignoring invalid fill value (must be 0-255): {}", tileFill);
+      throw new InvalidConfigurationException(
+        "--fill-value must be between 0 and 255");
     }
   }
 
@@ -888,6 +905,13 @@ public class Converter implements Callable<Integer> {
   )
   public void setReaderOptions(List<String> readerOpts) {
     if (readerOpts != null) {
+      for (String option : readerOpts) {
+        String[] pair = option.split("=", 2);
+        if (pair.length != 2 || pair[0].isEmpty() || pair[1].isEmpty()) {
+          throw new InvalidConfigurationException(
+            "--options entries must use non-empty key=value syntax");
+        }
+      }
       readerOptions = readerOpts;
     }
     else {
@@ -997,12 +1021,8 @@ public class Converter implements Callable<Integer> {
       defaultValue = "" + MIN_SIZE
   )
   public void setMinImageSize(int min) {
-    if (min > 0) {
-      minSize = min;
-    }
-    else {
-      LOGGER.warn("Ignoring invalid minimum image size: {}", min);
-    }
+    requirePositive("--target-min-size", min);
+    minSize = min;
   }
 
   /**
@@ -1360,6 +1380,164 @@ public class Converter implements Callable<Integer> {
     return dimensionOrder;
   }
 
+  private static void requirePositive(String option, int value) {
+    if (value <= 0) {
+      throw new InvalidConfigurationException(
+        option + " must be greater than zero");
+    }
+  }
+
+  private void validateConfiguration() {
+    if (maxWorkers <= 0 || tileWidth <= 0 || tileHeight <= 0 ||
+      chunkDepth <= 0 || shardWidth <= 0 || shardHeight <= 0 ||
+      shardDepth <= 0 || minSize <= 0)
+    {
+      throw new InvalidConfigurationException(
+        "converter defaults have not been initialized");
+    }
+    if (!nested && ngffVersion != SupportedVersions.NGFF_01) {
+      throw new InvalidConfigurationException(
+        "--no-nested is only compatible with --ngff-version 0.1");
+    }
+    validateCompressionProperties();
+  }
+
+  private void validateCompressionProperties() {
+    if (compressionType == null || compressionProperties == null) {
+      throw new InvalidConfigurationException(
+        "compression settings have not been initialized");
+    }
+    List<String> allowed;
+    switch (compressionType) {
+      case raw:
+        allowed = new ArrayList<String>();
+        break;
+      case blosc:
+        allowed = Arrays.asList("cname", "clevel", "blocksize", "shuffle");
+        break;
+      case zlib:
+      case gzip:
+        allowed = Arrays.asList("level");
+        break;
+      case zstd:
+        allowed = Arrays.asList("level", "checksum");
+        break;
+      default:
+        throw new InvalidConfigurationException(
+          "unsupported compression type " + compressionType);
+    }
+    for (String key : compressionProperties.keySet()) {
+      if (!allowed.contains(key)) {
+        throw new InvalidConfigurationException(
+          "unsupported " + compressionType + " compression property: " + key);
+      }
+    }
+    if (getV3() && compressionType == ZarrCompression.zlib) {
+      throw new InvalidConfigurationException(
+        "Zarr v3 does not support zlib compression");
+    }
+    if (!getV3() && (compressionType == ZarrCompression.gzip ||
+      compressionType == ZarrCompression.zstd))
+    {
+      throw new InvalidConfigurationException(
+        "Zarr v2 does not support " + compressionType + " compression");
+    }
+    if (compressionType == ZarrCompression.raw &&
+      !compressionProperties.isEmpty())
+    {
+      throw new InvalidConfigurationException(
+        "uncompressed output does not accept compression properties");
+    }
+    if (compressionType == ZarrCompression.blosc) {
+      validateIntegerProperty("clevel", 0, 9, 5);
+      validateIntegerProperty("blocksize", 0, Integer.MAX_VALUE, 0);
+      String cname = property("cname", "lz4");
+      if (!Arrays.asList("lz4", "zstd", "zlib", "blosclz", "lz4hc")
+        .contains(cname))
+      {
+        throw new InvalidConfigurationException(
+          "invalid blosc cname: " + cname);
+      }
+      String shuffle = property("shuffle", "shuffle");
+      if (!Arrays.asList("noshuffle", "shuffle", "bitshuffle")
+        .contains(shuffle))
+      {
+        throw new InvalidConfigurationException(
+          "invalid blosc shuffle value: " + shuffle);
+      }
+    }
+    else if (compressionType == ZarrCompression.zlib ||
+      compressionType == ZarrCompression.gzip)
+    {
+      validateIntegerProperty("level", 0, 9,
+        compressionType == ZarrCompression.zlib ? 1 : 5);
+    }
+    else if (compressionType == ZarrCompression.zstd) {
+      validateIntegerProperty("level", -7, 22, 5);
+      String checksum = property("checksum", "true");
+      if (!(checksum.equals("true") || checksum.equals("false"))) {
+        throw new InvalidConfigurationException(
+          "zstd checksum must be true or false");
+      }
+    }
+  }
+
+  private String property(String key, String fallback) {
+    return compressionProperties.getOrDefault(key, fallback).toString();
+  }
+
+  private void validateIntegerProperty(
+    String key, int minimum, int maximum, int fallback)
+  {
+    String value = property(key, Integer.toString(fallback));
+    try {
+      int parsed = Integer.parseInt(value);
+      if (parsed < minimum || parsed > maximum) {
+        throw new InvalidConfigurationException(
+          key + " must be between " + minimum + " and " + maximum);
+      }
+    }
+    catch (NumberFormatException e) {
+      throw new InvalidConfigurationException(
+        key + " must be an integer", e);
+    }
+  }
+
+  private void validateSeriesSelection(int imageCount) {
+    if (additionalScaleFormatStringArgs != null &&
+      additionalScaleFormatStringArgs.size() != imageCount)
+    {
+      throw new InvalidConfigurationException(
+        "--additional-scale-format-string-args must contain exactly " +
+        imageCount + " rows");
+    }
+    HashSet<Integer> unique = new HashSet<Integer>();
+    for (Integer index : seriesList) {
+      if (index < 0 || index >= imageCount) {
+        throw new InvalidConfigurationException(
+          "--series index " + index + " is outside the valid range 0-" +
+          (imageCount - 1));
+      }
+      if (!unique.add(index)) {
+        throw new InvalidConfigurationException(
+          "--series index " + index + " was specified more than once");
+      }
+    }
+  }
+
+  private void validateScaleFormat() {
+    try {
+      for (Integer index : seriesList) {
+        String.format(scaleFormatString,
+          getScaleFormatStringArgs(index, 0));
+      }
+    }
+    catch (IllegalFormatException | IndexOutOfBoundsException e) {
+      throw new InvalidConfigurationException(
+        "invalid --scale-format-string or additional argument CSV", e);
+    }
+  }
+
   // Conversion methods
 
   /**
@@ -1388,15 +1566,12 @@ public class Converter implements Callable<Integer> {
     }
 
     if (inputPath == null) {
-      throw new IllegalArgumentException("Input path not specified");
+      throw new InvalidConfigurationException("input path not specified");
     }
     if (outputLocation == null) {
-      throw new IllegalArgumentException("Output location not specified");
+      throw new InvalidConfigurationException("output location not specified");
     }
-
-    if (fillValue != null && (fillValue < 0 || fillValue > 255)) {
-      throw new IllegalArgumentException("Invalid fill value: " + fillValue);
-    }
+    validateConfiguration();
     if (tileWidth != 1024 || tileHeight != 1024) {
       LOGGER.warn("Non-default tile size: {} x {}. " +
         "This may cause performance issues in some applications.",
@@ -1568,6 +1743,8 @@ public class Converter implements Callable<Integer> {
       try {
         meta = (IMetadata) v.getMetadataStore();
         ((OMEXMLMetadata) meta).resolveReferences();
+        int originalImageCount = meta.getImageCount();
+        validateSeriesSelection(originalImageCount);
 
         if (!noHCS) {
           noHCS = !hasValidPlate(meta);
@@ -1661,6 +1838,7 @@ public class Converter implements Callable<Integer> {
       if (!noHCS) {
         scaleFormatString = "%s/%s/%d/%d";
       }
+      validateScaleFormat();
 
       writeZarrMetadata();
 
@@ -3334,7 +3512,7 @@ public class Converter implements Callable<Integer> {
         ImageReader.getDefaultReaderClasses();
 
     for (Class<?> reader : extraReaders) {
-      readerClasses.addClass(0, (Class<IFormatReader>) reader);
+      readerClasses.addClass(0, reader.asSubclass(IFormatReader.class));
       LOGGER.debug("Added extra reader: {}", reader);
     }
 

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import loci.common.Constants;
 import loci.common.Region;
@@ -225,6 +226,7 @@ public class Converter implements Callable<Integer> {
   private volatile BlockingQueue<Runnable> queue;
 
   private volatile ExecutorService executor;
+  private volatile Class<?> baseReaderClass;
 
   /**
    * The source file's pixel type.  Retrieved from
@@ -244,6 +246,7 @@ public class Converter implements Callable<Integer> {
   private volatile Path outputPath;
 
   private IProgressListener progressListener;
+  private volatile boolean outputStarted = false;
   private Map<Integer, int[]> tileCounts = new HashMap<Integer, int[]>();
   private Map<String, List<long[]>> shardOffsets =
     new HashMap<String, List<long[]>>();
@@ -1388,6 +1391,7 @@ public class Converter implements Callable<Integer> {
   }
 
   private void validateConfiguration() {
+    outputStarted = false;
     if (maxWorkers <= 0 || tileWidth <= 0 || tileHeight <= 0 ||
       chunkDepth <= 0 || shardWidth <= 0 || shardHeight <= 0 ||
       shardDepth <= 0 || minSize <= 0)
@@ -1615,6 +1619,9 @@ public class Converter implements Callable<Integer> {
       setProgressListener(new ProgressBarListener(logLevel));
     }
 
+    // Verify that the input can be opened before modifying an existing output.
+    baseReaderClass = getBaseReaderClass();
+
     if (outputLocation.contains("://")) {
 
       LOGGER.info("*** experimental remote filesystem support ***");
@@ -1632,14 +1639,16 @@ public class Converter implements Callable<Integer> {
       LOGGER.debug("path: {}", rest);
       LOGGER.debug("opts: {}", outputOptions);
 
-      FileSystem fs = FileSystems.newFileSystem(endpoint, outputOptions);
+      Map<String, String> options = outputOptions == null ?
+        new HashMap<String, String>() : outputOptions;
+      FileSystem fs = FileSystems.newFileSystem(endpoint, options);
       outputPath = fs.getPath(bucket, rest);
       if (Files.exists(outputPath)) {
         if (overwrite) {
-          LOGGER.warn("overwriting on remote filesystem not yet supported");
+          throw new IOException(
+            "overwriting on remote filesystems is not supported");
         }
-        throw new IllegalArgumentException(
-                "Output path " + outputPath + " already exists.");
+        throw new IOException("output path " + outputPath + " already exists");
       }
     }
     else {
@@ -1647,14 +1656,9 @@ public class Converter implements Callable<Integer> {
 
       if (Files.exists(outputPath)) {
         if (!overwrite) {
-          throw new IllegalArgumentException(
-                  "Output path " + outputPath + " already exists");
+          throw new IOException(
+            "output path " + outputPath + " already exists");
         }
-        LOGGER.warn("Overwriting output path {}", outputPath);
-        Files.walk(outputPath)
-                .sorted(Comparator.reverseOrder())
-                .map(Path::toFile)
-                .forEach(File::delete);
       }
     }
 
@@ -1686,7 +1690,8 @@ public class Converter implements Callable<Integer> {
         .build();
 
     // First find which reader class we need
-    Class<?> readerClass = getBaseReaderClass();
+    Class<?> readerClass = baseReaderClass == null ?
+      getBaseReaderClass() : baseReaderClass;
 
     // Now with our found type instantiate our queue of readers for use
     // during conversion
@@ -1743,6 +1748,7 @@ public class Converter implements Callable<Integer> {
       // Finally, perform conversion on all series
       IFormatReader v = readers.take();
       IMetadata meta = null;
+      String originalMetadataXml = null;
       try {
         meta = (IMetadata) v.getMetadataStore();
         ((OMEXMLMetadata) meta).resolveReferences();
@@ -1812,15 +1818,7 @@ public class Converter implements Callable<Integer> {
           for (int s=0; s<meta.getImageCount(); s++) {
             service.addMetadataOnly((OMEXMLMetadata) meta, s, s == 0);
           }
-          String xml = service.getOMEXML(meta);
-
-          // write the original OME-XML to a file
-          Path metadataPath = getRootPath().resolve("OME");
-          if (!Files.exists(metadataPath)) {
-            Files.createDirectories(metadataPath);
-          }
-          Path omexmlFile = metadataPath.resolve(METADATA_FILE);
-          Files.write(omexmlFile, xml.getBytes(Constants.ENCODING));
+          originalMetadataXml = service.getOMEXML(meta);
         }
       }
       catch (ServiceException se) {
@@ -1841,6 +1839,17 @@ public class Converter implements Callable<Integer> {
         scaleFormatString = "%s/%s/%d/%d";
       }
       validateScaleFormat();
+      prepareOutput();
+
+      if (originalMetadataXml != null) {
+        Path metadataPath = getRootPath().resolve("OME");
+        if (!Files.exists(metadataPath)) {
+          Files.createDirectories(metadataPath);
+        }
+        Path omexmlFile = metadataPath.resolve(METADATA_FILE);
+        Files.write(omexmlFile,
+          originalMetadataXml.getBytes(Constants.ENCODING));
+      }
 
       writeZarrMetadata();
 
@@ -2124,10 +2133,41 @@ public class Converter implements Callable<Integer> {
    * @return directory into which Zarr and OME-XML data is written
    */
   private Path getRootPath() {
-    if (pyramidName == null) {
-      return outputPath;
+    Path rootPath = outputPath;
+    if (rootPath == null) {
+      throw new IllegalStateException("output path has not been initialized");
     }
-    return outputPath.resolve(pyramidName);
+    String name = pyramidName;
+    if (name == null) {
+      return rootPath;
+    }
+    return rootPath.resolve(name);
+  }
+
+  private void prepareOutput() throws IOException {
+    Path path = outputPath;
+    if (path == null) {
+      throw new IllegalStateException("output path has not been initialized");
+    }
+    if (Files.exists(path)) {
+      if (outputLocation.contains("://")) {
+        throw new IOException(
+          "overwriting on remote filesystems is not supported");
+      }
+      if (!overwrite) {
+        throw new IOException("output path " + path + " already exists");
+      }
+      LOGGER.warn("Overwriting output path {}", path);
+      outputStarted = true;
+      try (Stream<Path> paths = Files.walk(path)) {
+        Iterable<Path> ordered = () ->
+          paths.sorted(Comparator.reverseOrder()).iterator();
+        for (Path existing : ordered) {
+          Files.delete(existing);
+        }
+      }
+    }
+    outputStarted = true;
   }
 
   /**

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -10,6 +10,7 @@ package com.glencoesoftware.bioformats2raw;
 import java.io.File;
 import java.io.IOException;
 import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -93,6 +94,8 @@ import com.univocity.parsers.csv.CsvParserSettings;
 
 import ch.qos.logback.classic.Level;
 import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.IVersionProvider;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import ucar.ma2.InvalidRangeException;
@@ -115,6 +118,11 @@ import dev.zarr.zarrjava.v3.codec.core.ShardingIndexedCodec;
 /**
  * Command line tool for converting whole slide imaging files to Zarr.
  */
+@Command(
+  name = "bioformats2raw",
+  description = "Convert microscopy image data to OME-Zarr.",
+  versionProvider = Converter.VersionProvider.class
+)
 public class Converter implements Callable<Integer> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Converter.class);
@@ -548,7 +556,7 @@ public class Converter implements Callable<Integer> {
   @Option(
     names = "--version",
     description = "Print version information and exit",
-    help = true,
+    versionHelp = true,
     defaultValue = "false"
   )
   public void setPrintVersionOnly(boolean versionOnly) {
@@ -1545,8 +1553,7 @@ public class Converter implements Callable<Integer> {
   // Conversion methods
 
   /**
-   * @return 0 if conversion completed without error,
-   *         -1 if conversion was not performed
+   * @return 0 if conversion completed without error
    * @throws Exception on most conversion errors
    */
   @Override
@@ -1554,20 +1561,6 @@ public class Converter implements Callable<Integer> {
     ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger)
         LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     root.setLevel(Level.toLevel(logLevel));
-
-    if (help) {
-      return -1;
-    }
-
-    if (printVersion) {
-      String version = Optional.ofNullable(
-        this.getClass().getPackage().getImplementationVersion()
-        ).orElse("development");
-      System.out.println("Version = " + version);
-      System.out.println("Bio-Formats version = " + FormatTools.VERSION);
-      System.out.println("NGFF specification version = " + getNGFFVersion());
-      return -1;
-    }
 
     if (inputPath == null) {
       throw new InvalidConfigurationException("input path not specified");
@@ -2144,7 +2137,7 @@ public class Converter implements Callable<Integer> {
     return rootPath.resolve(name);
   }
 
-  private void prepareOutput() throws IOException {
+  void prepareOutput() throws IOException {
     Path path = outputPath;
     if (path == null) {
       throw new IllegalStateException("output path has not been initialized");
@@ -3882,12 +3875,136 @@ public class Converter implements Callable<Integer> {
     return progressListener;
   }
 
+  /** Supplies version text for picocli's version-help handling. */
+  public static class VersionProvider implements IVersionProvider {
+
+    @Override
+    public String[] getVersion() {
+      String version = Optional.ofNullable(
+        Converter.class.getPackage().getImplementationVersion()
+        ).orElse("development");
+      return new String[] {
+        "bioformats2raw " + version,
+        "Bio-Formats version = " + FormatTools.VERSION,
+        "NGFF specification version = " + SupportedVersions.NGFF_04
+      };
+    }
+  }
+
+  static int execute(String[] args) {
+    return execute(args, new PrintWriter(System.out, true),
+      new PrintWriter(System.err, true));
+  }
+
+  static int execute(String[] args, PrintWriter out, PrintWriter err) {
+    return execute(new Converter(), args, out, err);
+  }
+
+  static int execute(
+    Converter converter, String[] args, PrintWriter out, PrintWriter err)
+  {
+    CommandLine commandLine = new CommandLine(converter);
+    commandLine.setOut(out);
+    commandLine.setErr(err);
+    commandLine.setParameterExceptionHandler((exception, arguments) -> {
+      Throwable invalid = findCause(
+        exception, InvalidConfigurationException.class);
+      printCliError(commandLine, invalid == null ?
+        exception.getMessage() : message(invalid));
+      return CommandLine.ExitCode.USAGE;
+    });
+    commandLine.setExecutionExceptionHandler(
+      (exception, cmd, parseResult) -> handleExecutionException(
+        converter, cmd, exception));
+    return commandLine.execute(args);
+  }
+
+  private static int handleExecutionException(
+    Converter converter, CommandLine commandLine, Exception exception)
+  {
+    if (hasCause(exception, InterruptedException.class)) {
+      Thread.currentThread().interrupt();
+      printCliError(commandLine, "conversion interrupted");
+      printPartialOutputWarning(converter, commandLine);
+      return 130;
+    }
+    if (hasCause(exception, InvalidConfigurationException.class)) {
+      Throwable invalid = findCause(
+        exception, InvalidConfigurationException.class);
+      printCliError(commandLine, message(invalid));
+      return CommandLine.ExitCode.USAGE;
+    }
+
+    printCliError(commandLine, message(exception));
+    if (isDebug(converter)) {
+      exception.printStackTrace(commandLine.getErr());
+    }
+    printPartialOutputWarning(converter, commandLine);
+    return CommandLine.ExitCode.SOFTWARE;
+  }
+
+  private static void printCliError(
+    CommandLine commandLine, String message)
+  {
+    commandLine.getErr().println(commandLine.getCommandName() + ": " + message);
+    commandLine.getErr().println(
+      "Try '" + commandLine.getCommandName() +
+      " --help' for more information.");
+  }
+
+  private static void printPartialOutputWarning(
+    Converter converter, CommandLine commandLine)
+  {
+    if (converter.outputStarted && converter.outputLocation != null) {
+      commandLine.getErr().println(
+        commandLine.getCommandName() + ": output '" +
+        converter.outputLocation + "' may be incomplete");
+    }
+  }
+
+  private static boolean isDebug(Converter converter) {
+    return "DEBUG".equals(converter.logLevel) ||
+      "TRACE".equals(converter.logLevel) ||
+      "ALL".equals(converter.logLevel);
+  }
+
+  private static boolean hasCause(
+    Throwable throwable, Class<? extends Throwable> type)
+  {
+    return findCause(throwable, type) != null;
+  }
+
+  private static Throwable findCause(
+    Throwable throwable, Class<? extends Throwable> type)
+  {
+    Throwable current = throwable;
+    while (current != null) {
+      if (type.isInstance(current)) {
+        return current;
+      }
+      current = current.getCause();
+    }
+    return null;
+  }
+
+  private static String message(Throwable throwable) {
+    Throwable current = throwable;
+    while (current.getCause() != null &&
+      (current.getMessage() == null || current.getMessage().isEmpty()))
+    {
+      current = current.getCause();
+    }
+    String value = current.getMessage();
+    return value == null || value.isEmpty() ?
+      current.getClass().getSimpleName() : value;
+  }
+
   /**
    * Perform file conversion as specified by command line arguments.
    * @param args command line arguments
    */
   public static void main(String[] args) {
-    int exitCode = new CommandLine(new Converter()).execute(args);
+    int exitCode = execute(args);
     System.exit(exitCode);
   }
 

--- a/src/main/java/com/glencoesoftware/bioformats2raw/InvalidConfigurationException.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/InvalidConfigurationException.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2026 Glencoe Software, Inc. All rights reserved.
+ *
+ * This software is distributed under the terms described by the LICENSE.txt
+ * file you can find at the root of the distribution bundle.  If the file is
+ * missing please request a copy by contacting info@glencoesoftware.com
+ */
+package com.glencoesoftware.bioformats2raw;
+
+/**
+ * Indicates that a command line or programmatic converter setting is invalid.
+ */
+class InvalidConfigurationException extends IllegalArgumentException {
+
+  InvalidConfigurationException(String message) {
+    super(message);
+  }
+
+  InvalidConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/test/java/com/glencoesoftware/bioformats2raw/ConverterCliTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/ConverterCliTest.java
@@ -1,0 +1,404 @@
+/**
+ * Copyright (c) 2026 Glencoe Software, Inc. All rights reserved.
+ *
+ * This software is distributed under the terms described by the LICENSE.txt
+ * file you can find at the root of the distribution bundle.  If the file is
+ * missing please request a copy by contacting info@glencoesoftware.com
+ */
+package com.glencoesoftware.bioformats2raw;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ConverterCliTest {
+
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void helpIsSuccessfulAndUsesStdout() {
+    Result result = execute("--help");
+
+    assertEquals(0, result.exitCode);
+    assertTrue(result.out.startsWith("Usage: bioformats2raw"));
+    assertEquals("", result.err);
+  }
+
+  @Test
+  void versionIsSuccessfulAndUsesStdout() {
+    Result result = execute("--version");
+
+    assertEquals(0, result.exitCode);
+    assertTrue(result.out.startsWith("bioformats2raw "));
+    assertTrue(result.out.contains("Bio-Formats version = "));
+    assertTrue(result.out.contains("NGFF specification version = 0.4"));
+    assertEquals("", result.err);
+  }
+
+  @Test
+  void missingOperandsAreUsageErrors() {
+    Result result = execute();
+
+    assertEquals(2, result.exitCode);
+    assertEquals("", result.out);
+    assertTrue(result.err.contains("input path not specified"));
+    assertTrue(result.err.contains("Try 'bioformats2raw --help'"));
+    assertFalse(result.err.contains("\tat "));
+  }
+
+  @Test
+  void unknownOptionIsAConciseUsageError() {
+    Result result = execute("--not-an-option");
+
+    assertEquals(2, result.exitCode);
+    assertEquals("", result.out);
+    assertTrue(result.err.contains("Unknown option: '--not-an-option'"));
+    assertFalse(result.err.contains("Usage: bioformats2raw"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidNumericOptions")
+  void invalidNumericValuesAreUsageErrors(String option, String value) {
+    Result result = execute(option, value, "input.fake", "output.zarr");
+
+    assertEquals(2, result.exitCode);
+    assertEquals("", result.out);
+    assertTrue(result.err.contains("must be"));
+    assertFalse(result.err.contains("\tat "));
+  }
+
+  static java.util.stream.Stream<Arguments> invalidNumericOptions() {
+    return java.util.stream.Stream.of(
+      Arguments.of("--resolutions", "0"),
+      Arguments.of("--tile-width", "0"),
+      Arguments.of("--tile-height", "-1"),
+      Arguments.of("--chunk-depth", "0"),
+      Arguments.of("--shard-width", "0"),
+      Arguments.of("--shard-height", "0"),
+      Arguments.of("--shard-depth", "0"),
+      Arguments.of("--max-workers", "0"),
+      Arguments.of("--max-cached-tiles", "-1"),
+      Arguments.of("--target-min-size", "0"),
+      Arguments.of("--fill-value", "256")
+    );
+  }
+
+  @Test
+  void invalidLogLevelAndReaderOptionAreUsageErrors() {
+    Result logLevel = execute(
+      "--log-level", "verbose", "input.fake", "output.zarr");
+    Result readerOption = execute(
+      "--options", "missing-value", "input.fake", "output.zarr");
+
+    assertEquals(2, logLevel.exitCode);
+    assertTrue(logLevel.err.contains("--log-level must be one of"));
+    assertEquals(2, readerOption.exitCode);
+    assertTrue(readerOption.err.contains("key=value"));
+  }
+
+  @Test
+  void invalidExtraReaderIsAUsageError() {
+    Result result = execute(
+      "--extra-readers", "java.lang.String", "input.fake", "output.zarr");
+
+    assertEquals(2, result.exitCode);
+    assertTrue(result.err.contains("must implement IFormatReader"));
+    assertFalse(result.err.contains("\tat "));
+  }
+
+  @Test
+  void incompatibleCompressionIsAUsageError() {
+    Result result = execute(
+      "--compression", "gzip", "input.fake", "output.zarr");
+
+    assertEquals(2, result.exitCode);
+    assertTrue(result.err.contains("Zarr v2 does not support gzip"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidCompressionProperties")
+  void invalidCompressionPropertiesAreUsageErrors(
+    String[] options, String expectedError)
+  {
+    String[] args = Arrays.copyOf(options, options.length + 2);
+    args[options.length] = "input.fake";
+    args[options.length + 1] = "output.zarr";
+
+    Result result = execute(args);
+
+    assertEquals(2, result.exitCode);
+    assertEquals("", result.out);
+    assertTrue(result.err.contains(expectedError));
+    assertFalse(result.err.contains("\tat "));
+  }
+
+  static java.util.stream.Stream<Arguments> invalidCompressionProperties() {
+    return java.util.stream.Stream.of(
+      Arguments.of(
+        new String[] {"-c", "blosc", "--compression-properties", "foo=1"},
+        "unsupported blosc compression property: foo"),
+      Arguments.of(
+        new String[] {"-c", "blosc", "--compression-properties", "clevel=10"},
+        "clevel must be between 0 and 9"),
+      Arguments.of(
+        new String[] {
+          "-c", "blosc", "--compression-properties", "cname=snappy"},
+        "invalid blosc cname: snappy"),
+      Arguments.of(
+        new String[] {
+          "-c", "blosc", "--compression-properties", "shuffle=maybe"},
+        "invalid blosc shuffle value: maybe"),
+      Arguments.of(
+        new String[] {"-c", "zlib", "--compression-properties", "level=fast"},
+        "level must be an integer"),
+      Arguments.of(
+        new String[] {"-c", "zlib", "--compression-properties", "level=10"},
+        "level must be between 0 and 9"),
+      Arguments.of(
+        new String[] {"--ngff-version", "0.5", "-c", "gzip",
+          "--compression-properties", "level=10"},
+        "level must be between 0 and 9"),
+      Arguments.of(
+        new String[] {"--ngff-version", "0.5", "-c", "zstd",
+          "--compression-properties", "level=23"},
+        "level must be between -7 and 22"),
+      Arguments.of(
+        new String[] {"--ngff-version", "0.5", "-c", "zstd",
+          "--compression-properties", "checksum=yes"},
+        "zstd checksum must be true or false")
+    );
+  }
+
+  @Test
+  void missingInputIsAnOperationalErrorWithoutStackTrace() {
+    Path output = temporaryDirectory.resolve("missing-input-output");
+    Result result = execute(
+      temporaryDirectory.resolve("missing.tif").toString(), output.toString());
+
+    assertEquals(1, result.exitCode);
+    assertEquals("", result.out);
+    assertTrue(result.err.contains("missing.tif"));
+    assertFalse(result.err.contains("\tat "));
+  }
+
+  @Test
+  void debugOperationalErrorIncludesStackTrace() {
+    Path output = temporaryDirectory.resolve("debug-output");
+    Result result = execute(
+      temporaryDirectory.resolve("missing.tif").toString(), output.toString(),
+      "--debug");
+
+    assertEquals(1, result.exitCode);
+    assertTrue(result.err.contains("java.io.FileNotFoundException"));
+    assertTrue(result.err.contains("\tat "));
+  }
+
+  @Test
+  void existingOutputIsAnOperationalError() throws Exception {
+    Path output = Files.createDirectory(temporaryDirectory.resolve("existing"));
+    Result result = execute("image.fake", output.toString());
+
+    assertEquals(1, result.exitCode);
+    assertTrue(result.err.contains("already exists"));
+    assertFalse(result.err.contains("may be incomplete"));
+  }
+
+  @Test
+  void overwritePreflightsInputBeforeDeletingOutput() throws Exception {
+    Path output = Files.createDirectory(
+      temporaryDirectory.resolve("preserved"));
+    Path marker = Files.createFile(output.resolve("marker"));
+    Result result = execute("--overwrite",
+      temporaryDirectory.resolve("missing.tif").toString(), output.toString());
+
+    assertEquals(1, result.exitCode);
+    assertTrue(Files.exists(marker));
+    assertFalse(result.err.contains("may be incomplete"));
+  }
+
+  @Test
+  void overwritePreservesOutputWhenScaleFormatIsInvalid() throws Exception {
+    Path output = Files.createDirectory(
+      temporaryDirectory.resolve("invalid-format-preserved"));
+    Path marker = Files.createFile(output.resolve("marker"));
+
+    Result result = execute("--overwrite", "--scale-format-string", "%q",
+      "image.fake", output.toString());
+
+    assertEquals(2, result.exitCode);
+    assertTrue(Files.exists(marker));
+    assertFalse(Files.exists(output.resolve("OME")));
+    assertFalse(result.err.contains("may be incomplete"));
+  }
+
+  @Test
+  void overwriteStopsWhenAPathCannotBeDeleted() throws Exception {
+    Assumptions.assumeTrue(
+      FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+    Path output = Files.createDirectory(temporaryDirectory.resolve("readonly"));
+    Path marker = Files.createFile(output.resolve("marker"));
+    Set<PosixFilePermission> original =
+      Files.getPosixFilePermissions(output);
+    Files.setPosixFilePermissions(
+      output, PosixFilePermissions.fromString("r-xr-xr-x"));
+    try {
+      Result result = execute("--overwrite", "image.fake", output.toString());
+
+      assertEquals(1, result.exitCode);
+      assertTrue(Files.exists(marker));
+      assertTrue(result.err.contains("may be incomplete"));
+    }
+    finally {
+      Files.setPosixFilePermissions(output, original);
+    }
+  }
+
+  @Test
+  void conversionFailureReportsPartialOutput() {
+    Path output = temporaryDirectory.resolve("partial");
+    Converter failing = new Converter() {
+      @Override
+      public void convert() throws java.io.IOException {
+        prepareOutput();
+        throw new java.io.IOException("simulated write failure");
+      }
+    };
+    Result result = execute(failing, "image.fake", output.toString());
+
+    assertEquals(1, result.exitCode);
+    assertTrue(result.err.contains("simulated write failure"));
+    assertTrue(result.err.contains(
+      "output '" + output + "' may be incomplete"));
+  }
+
+  @Test
+  void interruptionReturns130AndRestoresInterruptFlag() {
+    Path output = temporaryDirectory.resolve("interrupted");
+    Converter interrupted = new Converter() {
+      @Override
+      public void convert() throws InterruptedException {
+        throw new InterruptedException("simulated interruption");
+      }
+    };
+    try {
+      Result result = execute(interrupted, "image.fake", output.toString());
+
+      assertEquals(130, result.exitCode);
+      assertTrue(Thread.currentThread().isInterrupted());
+      assertTrue(result.err.contains("conversion interrupted"));
+    }
+    finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  void outOfRangeSeriesIsAUsageError() {
+    Path output = temporaryDirectory.resolve("series-output");
+    Result result = execute(
+      "--series", "2", "image.fake", output.toString());
+
+    assertEquals(2, result.exitCode);
+    assertTrue(result.err.contains("outside the valid range"));
+  }
+
+  @Test
+  void duplicateSeriesIsAUsageError() {
+    Path output = temporaryDirectory.resolve("duplicate-series-output");
+    Result result = execute(
+      "--series", "0,0", "image.fake", output.toString());
+
+    assertEquals(2, result.exitCode);
+    assertTrue(result.err.contains(
+      "series index 0 was specified more than once"));
+  }
+
+  @Test
+  void incorrectAdditionalArgumentCsvRowCountIsAUsageError()
+    throws Exception
+  {
+    Path csv = temporaryDirectory.resolve("additional-arguments.csv");
+    Files.write(csv, Arrays.asList("first", "second"));
+    Path output = temporaryDirectory.resolve("csv-row-count-output");
+
+    Result result = execute(
+      "--additional-scale-format-string-args", csv.toString(),
+      "image.fake", output.toString());
+
+    assertEquals(2, result.exitCode);
+    assertTrue(result.err.contains("must contain exactly 1 rows"));
+  }
+
+  @Test
+  void invalidScaleFormatIsAUsageError() {
+    Path output = temporaryDirectory.resolve("format-output");
+    Result result = execute(
+      "--scale-format-string", "%q", "image.fake", output.toString());
+
+    assertEquals(2, result.exitCode);
+    assertTrue(result.err.contains("invalid --scale-format-string"));
+  }
+
+  @Test
+  void publicSettersRejectInvalidValues() {
+    Converter converter = new Converter();
+
+    assertThrows(IllegalArgumentException.class,
+      () -> converter.setTileWidth(0));
+    assertThrows(IllegalArgumentException.class,
+      () -> converter.setMaxWorkers(-1));
+    assertThrows(IllegalArgumentException.class,
+      () -> converter.setFillValue((short) 256));
+    assertThrows(IllegalArgumentException.class,
+      () -> converter.setSeriesList(Arrays.asList(0, -1)));
+    assertThrows(IllegalArgumentException.class,
+      () -> converter.setReaderOptions(Collections.singletonList("broken")));
+    assertThrows(IllegalArgumentException.class,
+      () -> converter.setExtraReaders(new Class<?>[] {String.class}));
+  }
+
+  private Result execute(String... args) {
+    return execute(new Converter(), args);
+  }
+
+  private Result execute(Converter converter, String... args) {
+    StringWriter out = new StringWriter();
+    StringWriter err = new StringWriter();
+    int exitCode = Converter.execute(converter, args,
+      new PrintWriter(out, true), new PrintWriter(err, true));
+    return new Result(exitCode, out.toString(), err.toString());
+  }
+
+  private static class Result {
+
+    private final int exitCode;
+    private final String out;
+    private final String err;
+
+    Result(int exitCode, String out, String err) {
+      this.exitCode = exitCode;
+      this.out = out;
+      this.err = err;
+    }
+  }
+}


### PR DESCRIPTION
Hej,

while I was setting up the conda builds, I found some weird behavior with the exit codes (with `--version` in particular with `-1`/ `255`, leading to some funny build logs), which were also out of match with `raw2ometiff`/Unix standard. This led me a bit down the rabbit hole of the converter's error handling, output streams and exit codes, and I ended up making a number of changes to make the CLI more predictable and safer. It now validates invalid settings before conversion starts, propagates errors that were previously swallowed, protects existing output during `--overwrite`, and gives the CLI consistent output streams and exit statuses.

It also adds focused CLI regression tests and removes obsolete converter code.

Several failure paths could previously continue with invalid values, return before reporting an asynchronous error, or modify an existing output before the input was fully opened and validated. The CLI also mixed informational and diagnostic output and did not consistently distinguish usage errors, operational failures, and interruption.

Together, this made automation less reliable and could leave users without a clear indication that conversion had failed, was rejected etc.

## Changes

### Validate converter configuration early

- Add `InvalidConfigurationException` for invalid CLI and programmatic settings.
- Reject non-positive tile, chunk, shard, worker, resolution, and target-size values.
- Validate cache size, fill value, log level, reader-option syntax, output options, and extra reader classes.
- Validate compression properties, codecs, levels, and Zarr-version compatibility.
- Reject negative, duplicate, and out-of-range series selections.
- Validate scale format strings and additional CSV arguments before writing output.
- Enforce compatibility between unnested output and NGFF version 0.1.

### Propagate conversion failures reliably

- Propagate reader initialization, metadata service, series, and asynchronous chunk failures to callers.
- Correctly unwrap unexpected asynchronous exceptions.
- Stop worker tasks safely when conversion is interrupted and restore the thread interrupt flag.
- Close all initialized readers during failure cleanup.
- Remove newly created memo files with checked filesystem operations and report cleanup failures as concise warnings.
- Fall back to pixel-type ranges when `OMERO` min/max calculation is unavailable.

### Make overwrite handling safer

- Open the input and complete input-dependent validation before modifying existing output.
- Preserve existing output when input or configuration validation fails.
- Reject overwrite requests on remote filesystems where safe deletion is unsupported.
- Delete local output paths in reverse order using checked operations, closing the `Files.walk` stream correctly.
- Stop immediately when an output path cannot be removed.
- Track whether output modification has begun so the CLI only warns about potentially incomplete output when appropriate.

### Standardize CLI behavior

- Add explicit `picocli` command metadata and version reporting.
- Send help and version output to standard output.
- Send logs, warnings, progress, and errors to standard error.
- Report routine errors concisely without a stack trace, retain stack traces when debug logging is enabled.
- Use stable exit statuses, in line with common Unix conventions, to distinguish between success, input/output failures, configuration errors, and interruption:

  | Status | Meaning |
  | ---: | --- |
  | `0` | Success, help, or version output |
  | `1` | Input, output, dependency, or conversion failure |
  | `2` | Command-line or configuration error |
  | `130` | Interrupted conversion |

- Warn when a failed or interrupted conversion may have left incomplete output.

### Tests and cleanup

- Add CLI regression coverage for output streams, exit statuses, invalid configuration, overwrite safety, partial output, and interruption.
- Remove unused converter state and the obsolete stopwatch helper.

I think especially in the context of cleanup and error handling, there can still a lot be done, but this I think is a good start to make the CLI more predictable and safer.