### PR TITLE
Fix zarrv3 concurrency

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -30,8 +30,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -243,34 +241,21 @@ public class Converter implements Callable<Integer> {
 
   private IProgressListener progressListener;
   private Map<Integer, int[]> tileCounts = new HashMap<Integer, int[]>();
-  private final ConcurrentMap<String, ConcurrentMap<ShardKey, Object>>
-    shardLocks =
-    new ConcurrentHashMap<String, ConcurrentMap<ShardKey, Object>>();
+  private final ShardLockRegistry shardLocks;
 
-  private static final class ShardKey {
+  /**
+   * Construct a converter.
+   */
+  public Converter() {
+    this(new ShardLockRegistry());
+  }
 
-    private final long[] coordinates;
-
-    ShardKey(long[] coordinates) {
-      this.coordinates = Arrays.copyOf(coordinates, coordinates.length);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (this == other) {
-        return true;
-      }
-      if (!(other instanceof ShardKey)) {
-        return false;
-      }
-      ShardKey key = (ShardKey) other;
-      return Arrays.equals(coordinates, key.coordinates);
-    }
-
-    @Override
-    public int hashCode() {
-      return Arrays.hashCode(coordinates);
-    }
+  /**
+   * Construct a converter using the supplied shard lock registry.
+   * @param shardLocks registry for active Zarr v3 shard locks
+   */
+  Converter(ShardLockRegistry shardLocks) {
+    this.shardLocks = shardLocks;
   }
 
   // Option setters
@@ -2045,33 +2030,24 @@ public class Converter implements Callable<Integer> {
 
     // if writing sharded data, we need to ensure that only one chunk
     // is written to each shard at a time (since one shard == one file)
-    ConcurrentMap<ShardKey, Object> arrayShardLocks = shardLocks.get(pathName);
-    if (arrayShardLocks != null &&
-      !isWholeShard(array, shape, offset))
-    {
-      dev.zarr.zarrjava.v3.Array v3Array = (dev.zarr.zarrjava.v3.Array) array;
+    if (!isWholeShard(array, shape, offset)) {
       int[] shardSizes = array.metadata().chunkShape();
       long[] shard = new long[shardSizes.length];
       for (int i=0; i<offset.length; i++) {
         shard[i] = offset[i] / shardSizes[i];
       }
-      // Lock on a shared object for these shard coordinates. Locking on
-      // 'shard' itself would not be sufficient because it is local to this
-      // invocation.
-      // this still allows chunks in other shards to be written,
-      // so minimizes the performance impact compared to just
-      // synchronizing the method
-      Object shardLock = arrayShardLocks.computeIfAbsent(
-        new ShardKey(shard), key -> new Object());
-      synchronized (shardLock) {
-        array.write(Utils.toLongArray(offset), pixels);
+      // Lock on the shared stripe for these shard coordinates. The fixed
+      // number of stripes bounds memory use while still allowing writes to
+      // shards assigned to different stripes to proceed in parallel.
+      if (shardLocks.runWithLock(pathName, shard,
+        () -> array.write(Utils.toLongArray(offset), pixels)))
+      {
+        return;
       }
     }
-    else {
-      // if not writing sharded data, each chunk gets written to a separate file
-      // so we're not worried about conflicting writes to the same file
-      array.write(Utils.toLongArray(offset), pixels);
-    }
+    // if not writing sharded data, each chunk gets written to a separate file
+    // so we're not worried about conflicting writes to the same file
+    array.write(Utils.toLongArray(offset), pixels);
   }
 
   private boolean isWholeShard(Array array, int[] shape, int[] offset) {
@@ -2615,11 +2591,10 @@ public class Converter implements Callable<Integer> {
             .withCodecs(c -> builder)
             .build()
         );
-        // Set up per-shard locks so that only one chunk is written to a shard
-        // at a time.
+        // Set up bounded lock stripes so that only one chunk is written to a
+        // shard at a time without retaining one lock for every touched shard.
         if (useSharding && writeImageData) {
-          shardLocks.put(resolutionString,
-            new ConcurrentHashMap<ShardKey, Object>());
+          shardLocks.register(resolutionString);
         }
       }
       else {

--- a/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java
@@ -30,6 +30,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -100,7 +102,6 @@ import dev.zarr.zarrjava.core.Group;
 import dev.zarr.zarrjava.core.chunkkeyencoding.Separator;
 import dev.zarr.zarrjava.store.FilesystemStore;
 import dev.zarr.zarrjava.store.StoreHandle;
-import dev.zarr.zarrjava.utils.IndexingUtils;
 import dev.zarr.zarrjava.utils.Utils;
 
 import dev.zarr.zarrjava.v3.ArrayMetadata;
@@ -242,8 +243,35 @@ public class Converter implements Callable<Integer> {
 
   private IProgressListener progressListener;
   private Map<Integer, int[]> tileCounts = new HashMap<Integer, int[]>();
-  private Map<String, List<long[]>> shardOffsets =
-    new HashMap<String, List<long[]>>();
+  private final ConcurrentMap<String, ConcurrentMap<ShardKey, Object>>
+    shardLocks =
+    new ConcurrentHashMap<String, ConcurrentMap<ShardKey, Object>>();
+
+  private static final class ShardKey {
+
+    private final long[] coordinates;
+
+    ShardKey(long[] coordinates) {
+      this.coordinates = Arrays.copyOf(coordinates, coordinates.length);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof ShardKey)) {
+        return false;
+      }
+      ShardKey key = (ShardKey) other;
+      return Arrays.equals(coordinates, key.coordinates);
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(coordinates);
+    }
+  }
 
   // Option setters
 
@@ -2017,7 +2045,8 @@ public class Converter implements Callable<Integer> {
 
     // if writing sharded data, we need to ensure that only one chunk
     // is written to each shard at a time (since one shard == one file)
-    if (shardOffsets.containsKey(pathName) &&
+    ConcurrentMap<ShardKey, Object> arrayShardLocks = shardLocks.get(pathName);
+    if (arrayShardLocks != null &&
       !isWholeShard(array, shape, offset))
     {
       dev.zarr.zarrjava.v3.Array v3Array = (dev.zarr.zarrjava.v3.Array) array;
@@ -2026,18 +2055,14 @@ public class Converter implements Callable<Integer> {
       for (int i=0; i<offset.length; i++) {
         shard[i] = offset[i] / shardSizes[i];
       }
-      // lock on one of the pre-computed shard offsets, as locking on
-      // 'shard' won't be sufficient
+      // Lock on a shared object for these shard coordinates. Locking on
+      // 'shard' itself would not be sufficient because it is local to this
+      // invocation.
       // this still allows chunks in other shards to be written,
       // so minimizes the performance impact compared to just
       // synchronizing the method
-      long[] shardLock = null;
-      for (long[] computedOffset : shardOffsets.get(pathName)) {
-        if (Arrays.equals(computedOffset, shard)) {
-          shardLock = computedOffset;
-          break;
-        }
-      }
+      Object shardLock = arrayShardLocks.computeIfAbsent(
+        new ShardKey(shard), key -> new Object());
       synchronized (shardLock) {
         array.write(Utils.toLongArray(offset), pixels);
       }
@@ -2590,17 +2615,11 @@ public class Converter implements Callable<Integer> {
             .withCodecs(c -> builder)
             .build()
         );
-        // pre-compute a list of shard offsets
-        // these will get used when writing to ensure that
-        // only one chunk gets written to a shard at a time
-        if (useSharding) {
-          ArrayList<long[]> shards = new ArrayList<long[]>();
-          long[][] shardCoords =
-            IndexingUtils.computeChunkCoords(arrayShape, shardSizes);
-          for (long[] shard : shardCoords) {
-            shards.add(shard);
-          }
-          shardOffsets.put(resolutionString, shards);
+        // Set up per-shard locks so that only one chunk is written to a shard
+        // at a time.
+        if (useSharding && writeImageData) {
+          shardLocks.put(resolutionString,
+            new ConcurrentHashMap<ShardKey, Object>());
         }
       }
       else {
@@ -2651,6 +2670,7 @@ public class Converter implements Callable<Integer> {
 
       getProgressListener().notifyResolutionStart(resolution, tileCount);
 
+      boolean allTasksSubmitted = false;
       try {
         for (int j=0; j<scaledHeight; j+=tileHeight) {
           final int yy = j;
@@ -2702,6 +2722,7 @@ public class Converter implements Callable<Integer> {
             }
           }
         }
+        allTasksSubmitted = true;
 
         // Wait until the entire resolution has completed before proceeding to
         // the next one
@@ -2713,6 +2734,13 @@ public class Converter implements Callable<Integer> {
 
       }
       finally {
+        // allOf only returns or throws after every submitted task has
+        // completed, so removing the shared locks is safe in that case. If
+        // task submission itself failed, retain the locks for any tasks that
+        // may still be running.
+        if (allTasksSubmitted) {
+          shardLocks.remove(resolutionString);
+        }
         getProgressListener().notifyResolutionEnd(resolution);
       }
     }

--- a/src/main/java/com/glencoesoftware/bioformats2raw/ShardLockRegistry.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/ShardLockRegistry.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2026 Glencoe Software, Inc. All rights reserved.
+ *
+ * This software is distributed under the terms described by the LICENSE.txt
+ * file you can find at the root of the distribution bundle.  If the file is
+ * missing please request a copy by contacting info@glencoesoftware.com
+ */
+package com.glencoesoftware.bioformats2raw;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+import dev.zarr.zarrjava.ZarrException;
+
+import ucar.ma2.InvalidRangeException;
+
+/**
+ * Stores bounded sets of shared lock stripes for sharded arrays that are
+ * currently being written. Shards assigned to the same stripe are serialized;
+ * in particular, the same shard is always assigned to the same stripe.
+ */
+final class ShardLockRegistry {
+
+  /**
+   * Keep enough stripes to make unrelated-shard contention unlikely while
+   * bounding retained lock state independently of the number of shards.
+   */
+  private static final int DEFAULT_STRIPE_COUNT = 1024;
+
+  private final ConcurrentMap<String, ConcurrentMap<Integer, Object>> locks =
+    new ConcurrentHashMap<String, ConcurrentMap<Integer, Object>>();
+  private final int stripeCount;
+  private final Supplier<Object> lockFactory;
+
+  ShardLockRegistry() {
+    this(DEFAULT_STRIPE_COUNT, Object::new);
+  }
+
+  ShardLockRegistry(Supplier<Object> lockFactory) {
+    this(DEFAULT_STRIPE_COUNT, lockFactory);
+  }
+
+  ShardLockRegistry(int stripeCount, Supplier<Object> lockFactory) {
+    if (stripeCount <= 0) {
+      throw new IllegalArgumentException("Stripe count must be positive");
+    }
+    this.stripeCount = stripeCount;
+    this.lockFactory = lockFactory;
+  }
+
+  void register(String path) {
+    locks.put(path, new ConcurrentHashMap<Integer, Object>());
+  }
+
+  boolean contains(String path) {
+    return locks.containsKey(path);
+  }
+
+  Object getOrCreate(String path, long[] coordinates) {
+    ConcurrentMap<Integer, Object> arrayLocks = locks.get(path);
+    if (arrayLocks == null) {
+      return null;
+    }
+    int stripe = Math.floorMod(Arrays.hashCode(coordinates), stripeCount);
+    return arrayLocks.computeIfAbsent(
+      stripe, key -> lockFactory.get());
+  }
+
+  boolean runWithLock(
+    String path, long[] coordinates, ShardOperation operation)
+    throws IOException, InvalidRangeException, ZarrException
+  {
+    Object lock = getOrCreate(path, coordinates);
+    if (lock == null) {
+      return false;
+    }
+    synchronized (lock) {
+      operation.run();
+    }
+    return true;
+  }
+
+  void remove(String path) {
+    locks.remove(path);
+  }
+
+  @FunctionalInterface
+  interface ShardOperation {
+
+    void run() throws IOException, InvalidRangeException, ZarrException;
+  }
+}

--- a/src/test/java/com/glencoesoftware/bioformats2raw/ShardLockRegistryTest.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/ShardLockRegistryTest.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2026 Glencoe Software, Inc. All rights reserved.
+ *
+ * This software is distributed under the terms described by the LICENSE.txt
+ * file you can find at the root of the distribution bundle.  If the file is
+ * missing please request a copy by contacting info@glencoesoftware.com
+ */
+package com.glencoesoftware.bioformats2raw;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import dev.zarr.zarrjava.store.FilesystemStore;
+import dev.zarr.zarrjava.v3.Array;
+import dev.zarr.zarrjava.v3.ArrayMetadata;
+import dev.zarr.zarrjava.v3.codec.Codec;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ShardLockRegistryTest {
+
+  private static final String ARRAY_PATH = "0/0";
+  private static final long[] SHARD_COORDINATES = {0, 0, 0, 1, 2};
+
+  /**
+   * Test that concurrent requests for the same shard atomically create one
+   * shared lock.
+   */
+  @Test
+  public void testAtomicLockCreation() throws Exception {
+    int workerCount = 32;
+    AtomicInteger locksCreated = new AtomicInteger();
+    ShardLockRegistry registry =
+      new ShardLockRegistry(() -> {
+        locksCreated.incrementAndGet();
+        return new Object();
+      });
+    registry.register(ARRAY_PATH);
+
+    ExecutorService executor = Executors.newFixedThreadPool(workerCount);
+    CountDownLatch ready = new CountDownLatch(workerCount);
+    CountDownLatch start = new CountDownLatch(1);
+    List<Future<Object>> locks = new ArrayList<Future<Object>>();
+    try {
+      for (int i=0; i<workerCount; i++) {
+        locks.add(executor.submit(() -> {
+          ready.countDown();
+          start.await();
+          return registry.getOrCreate(ARRAY_PATH, SHARD_COORDINATES);
+        }));
+      }
+
+      assertTrue(ready.await(10, TimeUnit.SECONDS));
+      start.countDown();
+
+      Object expected = locks.get(0).get(10, TimeUnit.SECONDS);
+      for (Future<Object> lock : locks) {
+        assertSame(expected, lock.get(10, TimeUnit.SECONDS));
+      }
+      assertEquals(1, locksCreated.get());
+    }
+    finally {
+      executor.shutdownNow();
+    }
+  }
+
+  /**
+   * Test that touching more shards than there are lock stripes does not retain
+   * additional locks.
+   */
+  @Test
+  public void testLockCountIsBounded() {
+    int stripeCount = 8;
+    AtomicInteger locksCreated = new AtomicInteger();
+    ShardLockRegistry registry =
+      new ShardLockRegistry(stripeCount, () -> {
+        locksCreated.incrementAndGet();
+        return new Object();
+      });
+    registry.register(ARRAY_PATH);
+
+    for (int shard=0; shard<1000; shard++) {
+      registry.getOrCreate(ARRAY_PATH, new long[] {shard});
+    }
+
+    assertEquals(stripeCount, locksCreated.get());
+  }
+
+  /**
+   * Test that two operations targeting the same shard cannot enter their
+   * synchronized sections concurrently.
+   */
+  @Test
+  public void testSameShardWritesAreSerialized() throws Exception {
+    ShardLockRegistry registry = new ShardLockRegistry();
+    registry.register(ARRAY_PATH);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CountDownLatch firstWriteEntered = new CountDownLatch(1);
+    CountDownLatch releaseFirstWrite = new CountDownLatch(1);
+    CountDownLatch attemptingWrite = new CountDownLatch(1);
+    CountDownLatch enteredWrite = new CountDownLatch(1);
+    AtomicReference<Thread> contender = new AtomicReference<Thread>();
+    try {
+      Future<?> firstWrite = executor.submit(() ->
+        registry.runWithLock(ARRAY_PATH, SHARD_COORDINATES, () -> {
+          firstWriteEntered.countDown();
+          try {
+            releaseFirstWrite.await();
+          }
+          catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+          }
+        }));
+      assertTrue(firstWriteEntered.await(10, TimeUnit.SECONDS));
+
+      Future<Boolean> secondWrite = executor.submit(() -> {
+        contender.set(Thread.currentThread());
+        attemptingWrite.countDown();
+        return registry.runWithLock(ARRAY_PATH, SHARD_COORDINATES, () ->
+          enteredWrite.countDown());
+      });
+
+      assertTrue(attemptingWrite.await(10, TimeUnit.SECONDS));
+      long deadline =
+        System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+      while (contender.get().getState() != Thread.State.BLOCKED &&
+        enteredWrite.getCount() != 0 && System.nanoTime() < deadline)
+      {
+        Thread.yield();
+      }
+      assertEquals(Thread.State.BLOCKED, contender.get().getState());
+      assertEquals(1, enteredWrite.getCount());
+
+      releaseFirstWrite.countDown();
+      assertTrue(enteredWrite.await(10, TimeUnit.SECONDS));
+      firstWrite.get(10, TimeUnit.SECONDS);
+      secondWrite.get(10, TimeUnit.SECONDS);
+    }
+    finally {
+      executor.shutdownNow();
+    }
+  }
+
+  /**
+   * Test that a completed resolution removes its shard locks.
+   * @param temporaryDirectory temporary conversion output directory
+   */
+  @Test
+  public void testLocksRemovedAfterResolution(@TempDir Path temporaryDirectory)
+    throws Exception
+  {
+    Path input = Paths.get("image&sizeX=64&sizeY=64.fake");
+    Path output = temporaryDirectory.resolve("output");
+    AtomicInteger locksCreated = new AtomicInteger();
+    ShardLockRegistry registry =
+      new ShardLockRegistry(() -> {
+        locksCreated.incrementAndGet();
+        return new Object();
+      });
+    Converter converter = new Converter(registry);
+    CommandLine.call(converter,
+      "--ngff-version", "0.5",
+      "--resolutions", "1",
+      "--max-workers", "2",
+      "--tile-width", "32",
+      "--tile-height", "32",
+      "--shard-width", "64",
+      "--shard-height", "64",
+      input.toString(), output.toString());
+
+    FilesystemStore store = new FilesystemStore(output);
+    Array array = Array.open(store.resolve("0", "0"));
+    Optional<Codec> shardingCodec =
+      ArrayMetadata.getShardingIndexedCodec(array.metadata().codecs);
+    assertTrue(shardingCodec.isPresent());
+
+    assertEquals(1, locksCreated.get());
+    assertFalse(registry.contains(ARRAY_PATH));
+  }
+}

--- a/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrV3Test.java
+++ b/src/test/java/com/glencoesoftware/bioformats2raw/test/ZarrV3Test.java
@@ -316,6 +316,36 @@ public class ZarrV3Test extends AbstractZarrTest {
   }
 
   /**
+   * Test that metadata-only conversion does not enumerate every possible
+   * shard.  The number of shards here is greater than Integer.MAX_VALUE,
+   * which cannot be represented by the array previously used to store all
+   * shard coordinates.
+   */
+  @Test
+  public void testNoTilesWithManyShards() throws Exception {
+    int size = 65536;
+    assertTrue((long) size * size > Integer.MAX_VALUE);
+    input = fake(
+      "sizeX", String.valueOf(size),
+      "sizeY", String.valueOf(size));
+    assertTool(
+      "--ngff-version", getNGFFVersion(),
+      "--no-tiles",
+      "--resolutions", "1",
+      "--tile-width", "1",
+      "--tile-height", "1",
+      "--shard-width", "1",
+      "--shard-height", "1");
+
+    Array array = Array.open(store.resolve("0", "0"));
+    assertArrayEquals(
+      new long[] {1, 1, 1, size, size}, array.metadata().shape);
+    Optional<Codec> shardingCodec =
+      ArrayMetadata.getShardingIndexedCodec(array.metadata().codecs);
+    assertTrue(shardingCodec.isPresent());
+  }
+
+  /**
    * Test invalid shard size.
    */
   @Test


### PR DESCRIPTION
Hej,

while looking at Zarr v3 sharded output, I found that the converter eagerly computed and retained the coordinates of every possible shard before writing started. Those coordinates were only used as shared lock objects so that chunks targeting the same shard could not write to the same file concurrently.

This works for ordinary image sizes, but the allocation grows with the total number of shards rather than with the amount of work actually being performed. It also happens for metadata-only conversion, where no shard data is written at all. Funnily, with sufficiently large arrays, computing the coordinate array can overflow before conversion starts. For example, a metadata-only 65536 x 65536 image using 1 x 1 shards fails on `master` with an `ArithmeticException`.

This replaces the eager coordinate list with a bounded, lazily populated lock registry. It preserves the existing same-shard serialization while avoiding memory growth based on the number of shards, retaining parallel writes across lock stripes, and releasing resolution-specific state once writing completes.

## Changes

### Avoid eagerly enumerating shards

- Remove the call to `IndexingUtils.computeChunkCoords` and the list containing every shard coordinate.
- Register lock state only for sharded Zarr v3 arrays that will actually write image data.
- Calculate the target shard directly from each chunk offset when the chunk is written.
- Avoid allocating shard lock state for metadata-only conversion.
- Replace the linear search through all shard coordinates with a concurrent hash lookup.

### Bound shard lock retention

- Move shard locking into a focused `ShardLockRegistry`.
- Hash shard coordinates into a fixed set of 1024 lock stripes per active resolution.
- Create locks lazily, so unused stripes do not allocate lock objects.
- Guarantee that chunks targeting the same shard use the same lock.
- Allow chunks assigned to different stripes to continue writing in parallel.
- Accept occasional serialization between unrelated shards that hash to the same stripe in exchange for a strict upper bound on retained lock state.

### Clean up resolution state safely

- Remove the registered lock stripes after all submitted tasks for a resolution have completed.
- Retain the registry if task submission itself fails, since already submitted tasks may still be running and require the shared locks.
- Prevent lock state from accumulating across resolutions and series during a successful conversion.

### Tests

- Add a metadata-only regression test with more than `Integer.MAX_VALUE` shards.
- Verify that concurrent requests for the same shard atomically obtain one shared lock.
- Verify that operations targeting the same shard are serialized.
- Verify that touching 1000 shards with eight configured stripes retains only eight locks.
- Verify that a completed resolution removes its registry entry.
- Preserve the existing sharded pixel-integrity coverage.

### Comparison with `master`

The serialization of chunks targeting the same shard was already present. This preserves that behavior. The improvement is that the coordination state is now lazy, bounded, should be faster to look up, and cleaned up after each resolution.

I think this keeps the original locking model and its parallelism benefits, while making sharded Zarr v3 conversion safer for very large arrays and metadata-only workflows.
