### PR TITLE
Remove reference to conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,9 @@ For additional information, please see:
 Installation
 ============
 
-1. Download and unpack a release artifact:
+Download and unpack a release artifact:
 
     https://github.com/glencoesoftware/bioformats2raw/releases
-
-2. OR, install via `conda` as described at [conda-bioformats2raw](https://github.com/ome/conda-bioformats2raw).
 
 Development Installation
 ========================


### PR DESCRIPTION
As discussed with @sbesson and @chris-allan, the reference to conda is being removed from the README to avoid confusion, since we do not maintain conda packages.

This is a documentation change only, so no testing is required (FYI @erindiel).