### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 Glencoe Software accepts Pull Requests on this repository on a case-by-case basis.
-All proposed contributions are subject to the current license on this repository (see `LICENSE.txt`).
+All proposed contributions are subject to the current license on this repository (see [LICENSE.txt](LICENSE.txt)).
 The Glencoe team reserves the right to close Pull Requests for any reason, with or without prior review.
 In most cases, we recommend opening an Issue first to document specific problems that need to be addressed. The same terms apply to Issues.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+Glencoe Software accepts Pull Requests on this repository on a case-by-case basis.
+All proposed contributions are subject to the current license on this repository (see `LICENSE.txt`).
+The Glencoe team reserves the right to close Pull Requests for any reason, with or without prior review.
+In most cases, we recommend opening an Issue first to document specific problems that need to be addressed. The same terms apply to Issues.
+
+All code contributions considered for inclusion are subject to a review process by one or more members of the Glencoe team.
+Successful contributors in all cases are expected to:
+
+- describe the proposed changes, why they are necessary, and how to test them
+- answer questions from the reviewers, which may include but are not limited to
+  questions about technical choices, relevant test cases, and impacts on existing
+  functionality
+- modify contributions, if necessary and appropriate, to address review comments
+- disclose the use of AI/LLM tools, if used to assist in creating any portion of the contribution (including but not limited to code, documentation, and text or visual description of the changes)
+
+Large-scale changes that significantly impact existing functionality or substantially re-write existing code are generally rejected without detailed review.


### PR DESCRIPTION
As discussed separately, this adds a `CONTRIBUTING.md` to clarify the policy for external contributions on this repository. See also https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors.