### PR TITLE
CQ1 reader: set brightfield channel color to white

### DIFF
--- a/src/main/java/com/glencoesoftware/bioformats2raw/CQ1Reader.java
+++ b/src/main/java/com/glencoesoftware/bioformats2raw/CQ1Reader.java
@@ -28,6 +28,7 @@ import ome.xml.model.Image;
 import ome.xml.model.Plate;
 import ome.xml.model.Well;
 import ome.xml.model.WellSample;
+import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
 
 import org.w3c.dom.Element;
@@ -46,6 +47,7 @@ public class CQ1Reader extends OMETiffReader {
     LoggerFactory.getLogger(CQ1Reader.class);
 
   private static final String MEASUREMENT_PROTOCOL = "MeasurementProtocol.xml";
+  private static final String BRIGHTFIELD_NAME = "Brightfield";
 
   private List<String> extraFiles = new ArrayList<String>();
   private transient boolean addPlateAcquisition = false;
@@ -127,6 +129,10 @@ public class CQ1Reader extends OMETiffReader {
       for (int c=0; c<getEffectiveSizeC(); c++) {
         if (c < channelNames.size()) {
           metadataStore.setChannelName(channelNames.get(c), i, c);
+          // explicitly set brightfield channels to white
+          if (channelNames.get(c).equals(BRIGHTFIELD_NAME)) {
+            metadataStore.setChannelColor(new Color(255, 255, 255, 255), i, c);
+          }
         }
       }
     }
@@ -297,7 +303,7 @@ public class CQ1Reader extends OMETiffReader {
             if (enabled == null || enabled.equalsIgnoreCase("true")) {
               String mode = channel.getAttribute("icm:Method");
               if (mode.equalsIgnoreCase("brightfield")) {
-                names.add("Brightfield");
+                names.add(BRIGHTFIELD_NAME);
               }
               else {
                 String lightSource = getAttribute(


### PR DESCRIPTION
Without this change, the `Color` on `Channel` in `OME/METADATA.ome.xml` was blank for `Brightfield` channels. The `color` attribute of the corresponding channel under `omero` in the Zarr metadata was set to red due to https://github.com/glencoesoftware/bioformats2raw/blob/master/src/main/java/com/glencoesoftware/bioformats2raw/Colors.java#L117 and https://github.com/glencoesoftware/bioformats2raw/blob/master/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java#L3287.

With this change, OME-XML and Zarr metadata should agree that the `Brightfield` channel is white.